### PR TITLE
ACTIN-82 Include trailing empty strings from known fusions

### DIFF
--- a/common/src/main/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoader.java
+++ b/common/src/main/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoader.java
@@ -5,14 +5,19 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.hartwig.serve.datamodel.serialization.util.SerializationUtil;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 public final class KnownFusionCacheLoader {
+
+    private static final Logger LOGGER = LogManager.getLogger(KnownFusionCacheLoader.class);
 
     private static final String FIELD_DELIMITER = ",";
 
@@ -60,13 +65,20 @@ public final class KnownFusionCacheLoader {
     private static KnownFusionData fromLine(@NotNull String line, @NotNull Map<String, Integer> fields) {
         String[] values = line.split(FIELD_DELIMITER);
 
-        return ImmutableKnownFusionData.builder()
-                .type(KnownFusionType.valueOf(values[fields.get(FLD_TYPE)]))
-                .fiveGene(values[fields.get(FLD_FIVE_GENE)])
-                .threeGene(values[fields.get(FLD_THREE_GENE)])
-                .cancerTypes(values[fields.get(FLD_CANCER_TYPES)])
-                .pubMedId(values[fields.get(FLD_PUB_MED)])
-                .highImpactPromiscuous(values[fields.get(FLD_HIGH_IMPACT_PROM)].equalsIgnoreCase("TRUE"))
-                .build();
+        try {
+            return ImmutableKnownFusionData.builder()
+                    .type(KnownFusionType.valueOf(values[fields.get(FLD_TYPE)]))
+                    .fiveGene(values[fields.get(FLD_FIVE_GENE)])
+                    .threeGene(values[fields.get(FLD_THREE_GENE)])
+                    .cancerTypes(values[fields.get(FLD_CANCER_TYPES)])
+                    .pubMedId(values[fields.get(FLD_PUB_MED)])
+                    .highImpactPromiscuous(values[fields.get(FLD_HIGH_IMPACT_PROM)].equalsIgnoreCase("TRUE"))
+                    .build();
+        } catch (ArrayIndexOutOfBoundsException e) {
+            LOGGER.error("Unable to parse line [{}] with fiels [{}]. Check the known_fusions CSV",
+                    line,
+                    fields.entrySet().stream().map(entry -> entry.getKey() + ":" + entry.getValue()).collect(Collectors.joining(",")));
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/common/src/main/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoader.java
+++ b/common/src/main/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoader.java
@@ -63,7 +63,7 @@ public final class KnownFusionCacheLoader {
 
     @NotNull
     private static KnownFusionData fromLine(@NotNull String line, @NotNull Map<String, Integer> fields) {
-        String[] values = line.split(FIELD_DELIMITER);
+        String[] values = line.split(FIELD_DELIMITER, -1);
 
         try {
             return ImmutableKnownFusionData.builder()

--- a/common/src/test/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoaderTest.java
+++ b/common/src/test/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoaderTest.java
@@ -1,11 +1,16 @@
 package com.hartwig.serve.common.knownfusion;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.google.common.io.Resources;
 
+import org.apache.logging.log4j.util.Strings;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class KnownFusionCacheLoaderTest {
@@ -17,6 +22,30 @@ public class KnownFusionCacheLoaderTest {
         KnownFusionCache cache = KnownFusionCacheLoader.load(KNOWN_FUSION_FILE);
 
         assertEquals(3, cache.knownFusions().size());
-        // TODO Expand test to cover all fields.
+
+        KnownFusionData fusion1 = findByThreeGene(cache.knownFusions(), "NTRK3");
+        assertEquals(KnownFusionType.PROMISCUOUS_3, fusion1.type());
+        assertEquals(Strings.EMPTY, fusion1.fiveGene());
+        assertEquals("<multiple>", fusion1.cancerTypes());
+        assertEquals("pubmed1", fusion1.pubMedId());
+        assertTrue(fusion1.highImpactPromiscuous());
+
+        KnownFusionData fusion2 = findByThreeGene(cache.knownFusions(), "ALK");
+        assertEquals(KnownFusionType.KNOWN_PAIR, fusion2.type());
+        assertEquals("EML4", fusion2.fiveGene());
+        assertEquals("<multiple>", fusion2.cancerTypes());
+        assertEquals("pubmed2", fusion2.pubMedId());
+        assertTrue(fusion2.highImpactPromiscuous());
+
+        KnownFusionData fusion3 = findByThreeGene(cache.knownFusions(), "AHR");
+        assertEquals(KnownFusionType.EXON_DEL_DUP, fusion3.type());
+        assertEquals("AHR", fusion3.fiveGene());
+        assertEquals("bladder", fusion3.cancerTypes());
+        assertEquals(Strings.EMPTY, fusion3.pubMedId());
+        assertFalse(fusion3.highImpactPromiscuous());
+    }
+
+    private static KnownFusionData findByThreeGene(@NotNull List<KnownFusionData> knownFusions, @NotNull String threeGeneToFind) {
+        return knownFusions.stream().filter(fusion -> fusion.threeGene().equals(threeGeneToFind)).findFirst().orElseThrow();
     }
 }

--- a/common/src/test/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoaderTest.java
+++ b/common/src/test/java/com/hartwig/serve/common/knownfusion/KnownFusionCacheLoaderTest.java
@@ -16,7 +16,7 @@ public class KnownFusionCacheLoaderTest {
     public void canLoadKnownFusionCache() throws IOException {
         KnownFusionCache cache = KnownFusionCacheLoader.load(KNOWN_FUSION_FILE);
 
-        assertEquals(2, cache.knownFusions().size());
+        assertEquals(3, cache.knownFusions().size());
         // TODO Expand test to cover all fields.
     }
 }

--- a/common/src/test/resources/known_fusion_cache/known_fusion_data.csv
+++ b/common/src/test/resources/known_fusion_cache/known_fusion_data.csv
@@ -1,3 +1,4 @@
 Type,FiveGene,ThreeGene,CancerTypes,PubMedId,KnownExonTranscript,KnownExonUpRange,KnownExonDownRange,HighImpactPromiscuous,Overrides
 PROMISCUOUS_3,,NTRK3,<multiple>,,,,,TRUE,
 KNOWN_PAIR,EML4,ALK,<multiple>,,,,,TRUE,
+EXON_DEL_DUP,AHR,AHR,<multiple>,,,,,,

--- a/common/src/test/resources/known_fusion_cache/known_fusion_data.csv
+++ b/common/src/test/resources/known_fusion_cache/known_fusion_data.csv
@@ -1,4 +1,4 @@
 Type,FiveGene,ThreeGene,CancerTypes,PubMedId,KnownExonTranscript,KnownExonUpRange,KnownExonDownRange,HighImpactPromiscuous,Overrides
-PROMISCUOUS_3,,NTRK3,<multiple>,,,,,TRUE,
-KNOWN_PAIR,EML4,ALK,<multiple>,,,,,TRUE,
-EXON_DEL_DUP,AHR,AHR,<multiple>,,,,,,
+PROMISCUOUS_3,,NTRK3,<multiple>,pubmed1,,,,TRUE,
+KNOWN_PAIR,EML4,ALK,<multiple>,pubmed2,,,,TRUE,
+EXON_DEL_DUP,AHR,AHR,bladder,,,,,,


### PR DESCRIPTION
Looks like some recent changes broke the known fusions file, the previous high promiscuous impact field container NA
and now it is empty string. This breaks the parsing which did a split with now limit option