### PR TITLE
ACTIN-146: Map JAX carcinoma of unknown primary to DOID 305

### DIFF
--- a/algo/README.md
+++ b/algo/README.md
@@ -348,6 +348,8 @@ Knowledge extraction is performed on a per-knowledgebase level after which all e
   - The actionable output is the database that [PROTECT](https://github.com/hartwigmedical/hmftools/tree/master/protect) bases its clinical evidence matching on.
   
 ## Version History and Download Links
+- Upcoming
+  - Map JAX carcinoma of unknown primary to DOID 305
 - [2.2.1](https://github.com/hartwigmedical/serve/releases/tag/serve-v2.2.1)
   - Fix bug reading the hartwig curated hotspot tsv instead of the genes tsv when extracting known genes. 
 - [2.2.0](https://github.com/hartwigmedical/serve/releases/tag/serve-v2.2.0)

--- a/algo/src/main/java/com/hartwig/serve/cancertype/CancerTypeConstants.java
+++ b/algo/src/main/java/com/hartwig/serve/cancertype/CancerTypeConstants.java
@@ -7,18 +7,19 @@ public final class CancerTypeConstants {
 
     public static final String CANCER_DOID = "162";
     public static final String ORGAN_SYSTEM_CANCER_DOID = "0050686";
+    public static final String CARCINOMA_OF_UNKNOWN_PRIMARY = "305";
     public static final String SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY = "1749";
     public static final String ADENOCARCINOMA_OF_UNKNOWN_PRIMARY = "299";
 
     // JAX defined some cancer types in a topology other than doid
     public static final String JAX_ADVANCES_SOLID_TUMORS = "10000003";
-    public static final String JAX_SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY = "10000009";
-    public static final String JAX_ADENOCARCINOMA_OF_UNKNOWN_PRIMARY = "10000008";
     public static final String JAX_NOT_CANCER = "10000005";
     public static final String JAX_CANCER_OF_UNKNOWN_PRIMARY = "10000006";
+    public static final String JAX_CARCINOMA_OF_UNKNOWN_PRIMARY = "10000007";
+    public static final String JAX_ADENOCARCINOMA_OF_UNKNOWN_PRIMARY = "10000008";
+    public static final String JAX_SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY = "10000009";
 
     // Cancer types which should be blacklisted for solid tumors
-    public static final CancerType CANCER_TYPE = ImmutableCancerType.builder().name("Cancer").doid(CANCER_DOID).build();
     public static final CancerType LEUKEMIA_TYPE = ImmutableCancerType.builder().name("Leukemia").doid("1240").build();
     public static final CancerType REFRACTORY_HEMATOLOGIC_TYPE =
             ImmutableCancerType.builder().name("Refractory hematologic cancer").doid("712").build();

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableEntryFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableEntryFactory.java
@@ -267,17 +267,14 @@ class ActionableEntryFactory {
         } else if (source.equalsIgnoreCase("jax")) {
             switch (id) {
                 case CancerTypeConstants.JAX_ADVANCES_SOLID_TUMORS:
-                    // CKB uses this as Advanced Solid Tumor
-                    return CancerTypeConstants.CANCER_DOID;
-                case CancerTypeConstants.JAX_SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY:
-                    // CKB uses this as Squamous Cell Carcinoma of Unknown Primary
-                    return CancerTypeConstants.SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY;
-                case CancerTypeConstants.JAX_ADENOCARCINOMA_OF_UNKNOWN_PRIMARY:
-                    // CKB uses this as Adenocarcinoma of Unknown Primary
-                    return CancerTypeConstants.ADENOCARCINOMA_OF_UNKNOWN_PRIMARY;
                 case CancerTypeConstants.JAX_CANCER_OF_UNKNOWN_PRIMARY:
-                    // CKB uses this as Cancer of Unknown Primary
                     return CancerTypeConstants.CANCER_DOID;
+                case CancerTypeConstants.JAX_CARCINOMA_OF_UNKNOWN_PRIMARY:
+                    return CancerTypeConstants.CARCINOMA_OF_UNKNOWN_PRIMARY;
+                case CancerTypeConstants.JAX_ADENOCARCINOMA_OF_UNKNOWN_PRIMARY:
+                    return CancerTypeConstants.ADENOCARCINOMA_OF_UNKNOWN_PRIMARY;
+                case CancerTypeConstants.JAX_SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY:
+                    return CancerTypeConstants.SQUAMOUS_CELL_CARCINOMA_OF_UNKNOWN_PRIMARY;
                 default:
                     // CKB uses 10000005 for configuring "Not a cancer". We can ignore these.
                     if (!id.equals(CancerTypeConstants.JAX_NOT_CANCER)) {


### PR DESCRIPTION
JAX introduced a new internal indication id for "carcinoma of unknown primary".

While it is not strictly correct to map to this to DOID 305 ("carcinoma"), in downstream algo's this leads to the desired outcomes.