### PR TITLE
OSP-84: Update the open recruitment types to include possible studies 

### DIFF
--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
@@ -25,8 +25,13 @@ import org.jetbrains.annotations.Nullable;
 class ActionableTrialFactory implements ActionableEntryFactory {
 
     private static final String SUB_FIELD_DELIMITER = ",";
-    private static final Set<String> POTENTIALLY_OPEN_RECRUITMENT_TYPES =
-            Set.of("recruiting", "not yet recruiting", "not_yet_recruiting", "approved for marketing", "available");
+    private static final Set<String> POTENTIALLY_OPEN_RECRUITMENT_TYPES = Set.of("recruiting",
+            "not yet recruiting",
+            "not_yet_recruiting",
+            "approved for marketing",
+            "available",
+            "enrolling by invitation",
+            "enrolling_by_invitation");
     private static final Set<String> COUNTRIES_TO_INCLUDE = Set.of("netherlands", "belgium", "germany");
     private static final Set<String> VARIANT_REQUIREMENT_TYPES_TO_INCLUDE = Set.of("partial - required", "required");
 

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
@@ -25,29 +25,12 @@ import org.jetbrains.annotations.Nullable;
 class ActionableTrialFactory implements ActionableEntryFactory {
 
     private static final String SUB_FIELD_DELIMITER = ",";
-    private static final Set<String> POTENTIALLY_OPEN_RECRUITMENT_TYPES = Sets.newHashSet();
-    private static final Set<String> COUNTRIES_TO_INCLUDE = Sets.newHashSet();
-    private static final Set<String> VARIANT_REQUIREMENT_TYPES_TO_INCLUDE = Sets.newHashSet();
+    private static final Set<String> POTENTIALLY_OPEN_RECRUITMENT_TYPES =
+            Set.of("recruiting", "not yet recruiting", "not_yet_recruiting", "approved for marketing", "available");
+    private static final Set<String> COUNTRIES_TO_INCLUDE = Set.of("netherlands", "belgium", "germany");
+    private static final Set<String> VARIANT_REQUIREMENT_TYPES_TO_INCLUDE = Set.of("partial - required", "required");
 
-    private static final Set<String> AGE_GROUPS_TO_INCLUDE = Sets.newHashSet();
-
-    static {
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("recruiting");
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("not yet recruiting");
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("not_yet_recruiting");
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("approved for marketing");
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("available");
-
-        COUNTRIES_TO_INCLUDE.add("netherlands");
-        COUNTRIES_TO_INCLUDE.add("belgium");
-        COUNTRIES_TO_INCLUDE.add("germany");
-
-        VARIANT_REQUIREMENT_TYPES_TO_INCLUDE.add("partial - required");
-        VARIANT_REQUIREMENT_TYPES_TO_INCLUDE.add("required");
-
-        AGE_GROUPS_TO_INCLUDE.add("adult");
-        AGE_GROUPS_TO_INCLUDE.add("senior");
-    }
+    private static final Set<String> AGE_GROUPS_TO_INCLUDE = Set.of("adult", "senior");
 
     @NotNull
     private final CkbStudyBlacklistModel blacklistStudy;
@@ -118,8 +101,8 @@ class ActionableTrialFactory implements ActionableEntryFactory {
     private static List<ClinicalTrial> trialsToInclude(@NotNull CkbEntry entry) {
         List<ClinicalTrial> filtered = Lists.newArrayList();
         for (ClinicalTrial trial : entry.clinicalTrials()) {
-            if (hasVariantRequirementTypeToInclude(trial.variantRequirementDetails(), entry) && hasPotentiallyOpenRequirementToInclude(trial.recruitment())
-                    && hasAgeGroupToInclude(trial.ageGroups())) {
+            if (hasVariantRequirementTypeToInclude(trial.variantRequirementDetails(), entry)
+                    && hasPotentiallyOpenRequirementToInclude(trial.recruitment()) && hasAgeGroupToInclude(trial.ageGroups())) {
                 filtered.add(trial);
             }
         }
@@ -131,8 +114,8 @@ class ActionableTrialFactory implements ActionableEntryFactory {
     static Set<String> countriesToInclude(@NotNull ClinicalTrial trial) {
         Set<String> countries = Sets.newHashSet();
         for (Location location : trial.locations()) {
-            if (COUNTRIES_TO_INCLUDE.contains(location.country().toLowerCase()) && hasPotentiallyOpenRequirementToInclude(
-                    location.status())) {
+            if (COUNTRIES_TO_INCLUDE.contains(location.country().toLowerCase())
+                    && hasPotentiallyOpenRequirementToInclude(location.status())) {
                 countries.add(location.country());
             }
         }
@@ -164,7 +147,7 @@ class ActionableTrialFactory implements ActionableEntryFactory {
     }
 
     @VisibleForTesting
-    static boolean hasPotentiallyOpenRequirementToInclude(@Nullable String locationStatus) {
-        return locationStatus == null || POTENTIALLY_OPEN_RECRUITMENT_TYPES.contains(locationStatus.toLowerCase());
+    static boolean hasPotentiallyOpenRequirementToInclude(@Nullable String recruitmentStatus) {
+        return recruitmentStatus == null || POTENTIALLY_OPEN_RECRUITMENT_TYPES.contains(recruitmentStatus.toLowerCase());
     }
 }

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
@@ -20,6 +20,7 @@ import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.sources.ckb.blacklist.CkbStudyBlacklistModel;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 class ActionableTrialFactory implements ActionableEntryFactory {
 
@@ -30,11 +31,9 @@ class ActionableTrialFactory implements ActionableEntryFactory {
 
     private static final Set<String> AGE_GROUPS_TO_INCLUDE = Sets.newHashSet();
 
-
     static {
         POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("recruiting");
         POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("not yet recruiting");
-        POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("unknown status");
         POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("not_yet_recruiting");
         POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("approved for marketing");
         POTENTIALLY_OPEN_RECRUITMENT_TYPES.add("available");
@@ -119,8 +118,8 @@ class ActionableTrialFactory implements ActionableEntryFactory {
     private static List<ClinicalTrial> trialsToInclude(@NotNull CkbEntry entry) {
         List<ClinicalTrial> filtered = Lists.newArrayList();
         for (ClinicalTrial trial : entry.clinicalTrials()) {
-            if (hasVariantRequirementTypeToInclude(trial.variantRequirementDetails(), entry) && POTENTIALLY_OPEN_RECRUITMENT_TYPES.contains(
-                    trial.recruitment().toLowerCase()) && hasAgeGroupToInclude(trial.ageGroups())) {
+            if (hasVariantRequirementTypeToInclude(trial.variantRequirementDetails(), entry) && hasPotentiallyOpenRequirementToInclude(trial.recruitment())
+                    && hasAgeGroupToInclude(trial.ageGroups())) {
                 filtered.add(trial);
             }
         }
@@ -132,8 +131,8 @@ class ActionableTrialFactory implements ActionableEntryFactory {
     static Set<String> countriesToInclude(@NotNull ClinicalTrial trial) {
         Set<String> countries = Sets.newHashSet();
         for (Location location : trial.locations()) {
-            if (COUNTRIES_TO_INCLUDE.contains(location.country().toLowerCase()) && (location.status() == null
-                    || POTENTIALLY_OPEN_RECRUITMENT_TYPES.contains(location.status().toLowerCase()))) {
+            if (COUNTRIES_TO_INCLUDE.contains(location.country().toLowerCase()) && hasPotentiallyOpenRequirementToInclude(
+                    location.status())) {
                 countries.add(location.country());
             }
         }
@@ -162,5 +161,10 @@ class ActionableTrialFactory implements ActionableEntryFactory {
             }
         }
         return false;
+    }
+
+    @VisibleForTesting
+    static boolean hasPotentiallyOpenRequirementToInclude(@Nullable String locationStatus) {
+        return locationStatus == null || POTENTIALLY_OPEN_RECRUITMENT_TYPES.contains(locationStatus.toLowerCase());
     }
 }

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
@@ -249,6 +249,8 @@ public class ActionableTrialFactoryTest {
         assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("not_yet_recruiting"));
         assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("approved for marketing"));
         assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("available"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("enrolling by invitation"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("enrolling_by_invitation"));
         assertFalse(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("unknown status"));
     }
 

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
@@ -242,6 +242,16 @@ public class ActionableTrialFactoryTest {
         assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Senior", "Adult")));
     }
 
+    @Test
+    public void hasPotentiallyOpenRequirementToInclude() {
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("recruiting"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("not yet recruiting"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("not_yet_recruiting"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("approved for marketing"));
+        assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("available"));
+        assertFalse(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("unknown status"));
+    }
+
     @NotNull
     private static ClinicalTrial createTrialWithMultipleLocations(@NotNull String recruitmentTrial, @NotNull String country1,
             @NotNull String recruitmentCountry1, @NotNull String country2, @NotNull String recruitmentCountry2) {


### PR DESCRIPTION
I have discussed the different recruitment types to include possible studies for interpretation. For this reason a small update is necessary to inlcude the following recruitment types: 

Recruiting
Not yet recruiting
Available
Approved for marketing
not_yet_recruiting --> It is for me not clear why we should interpret this? 

see ticket https://hartwigmedical.atlassian.net/browse/OSP-84 