### PR TITLE
OSP-85 Suggested refactoring to simplify use of treatment approaches

### DIFF
--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbTestFactory.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbTestFactory.java
@@ -1,6 +1,7 @@
 package com.hartwig.serve.sources.ckb;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -157,7 +158,6 @@ public final class CkbTestFactory {
                 .therapy(createTherapy(therapyName))
                 .indication(createIndication(indicationName, termId))
                 .responseType(responseType)
-                .relevantTreatmentApproaches(Lists.newArrayList())
                 .evidenceType(evidenceType)
                 .efficacyEvidence(Strings.EMPTY)
                 .approvalStatus(Strings.EMPTY)

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
@@ -6,7 +6,9 @@ import com.hartwig.serve.ckb.database.tables.Indicationevidence;
 import com.hartwig.serve.ckb.database.tables.Therapyevidence;
 import com.hartwig.serve.ckb.database.tables.Treatmentapproachevidence;
 import com.hartwig.serve.ckb.datamodel.reference.Reference;
+import com.hartwig.serve.ckb.datamodel.treatmentapproaches.DrugClassTreatmentApproach;
 import com.hartwig.serve.ckb.datamodel.treatmentapproaches.RelevantTreatmentApproaches;
+import com.hartwig.serve.ckb.datamodel.treatmentapproaches.TherapyTreatmentApproach;
 
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
@@ -71,7 +73,17 @@ class EvidenceDAO {
                 Indicationevidence.INDICATIONEVIDENCE.EVIDENCEID,
                 Indicationevidence.INDICATIONEVIDENCE.INDICATIONID).values(id, indicationId).execute();
 
-        for (RelevantTreatmentApproaches treatmentApproaches : evidence.relevantTreatmentApproaches()) {
+        for (DrugClassTreatmentApproach treatmentApproaches : evidence.drugTreatmentApproaches()) {
+            int treatmentApproachId = treatmentApproachDAO.write(treatmentApproaches);
+
+            context.insertInto(Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE,
+                            Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE.EVIDENCEID,
+                            Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE.TREATMENTAPPROACHEVIDENCEID)
+                    .values(id, treatmentApproachId)
+                    .execute();
+        }
+
+        for (TherapyTreatmentApproach treatmentApproaches : evidence.therapyTreatmentApproaches()) {
             int treatmentApproachId = treatmentApproachDAO.write(treatmentApproaches);
 
             context.insertInto(Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE,

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/TreatmentApproachDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/TreatmentApproachDAO.java
@@ -30,27 +30,7 @@ class TreatmentApproachDAO {
 
     }
 
-    @Nullable
-    private static TherapyTreatmentApproach extractOptionalTherapyTreatmentApproach(
-            @NotNull RelevantTreatmentApproaches treatmentApproaches) {
-        TherapyTreatmentApproach therapyTreatmentApproach = null;
-        if (treatmentApproaches.treatmentApproachIntervation() instanceof TherapyTreatmentApproach) {
-            therapyTreatmentApproach = (TherapyTreatmentApproach) treatmentApproaches.treatmentApproachIntervation();
-        }
-        return therapyTreatmentApproach;
-    }
-
-    @Nullable
-    private static DrugClassTreatmentApproach extractOptionalDrugClassTreatmentApproach(
-            @NotNull RelevantTreatmentApproaches treatmentApproaches) {
-        DrugClassTreatmentApproach drugClassTreatmentApproach = null;
-        if (treatmentApproaches.treatmentApproachIntervation() instanceof DrugClassTreatmentApproach) {
-            drugClassTreatmentApproach = (DrugClassTreatmentApproach) treatmentApproaches.treatmentApproachIntervation();
-        }
-        return drugClassTreatmentApproach;
-    }
-
-    public int write(@NotNull RelevantTreatmentApproaches treatmentApproaches) {
+    public int write(@NotNull DrugClassTreatmentApproach treatmentApproaches) {
         int id = context.insertInto(Treatmentapproach.TREATMENTAPPROACH,
                         Treatmentapproach.TREATMENTAPPROACH.TREATMENTAPPROACHID,
                         Treatmentapproach.TREATMENTAPPROACH.CREATEDATE,
@@ -60,16 +40,26 @@ class TreatmentApproachDAO {
                 .fetchOne()
                 .getValue(Treatmentapproach.TREATMENTAPPROACH.ID);
 
-        TherapyTreatmentApproach therapyTreatmentApproach = extractOptionalTherapyTreatmentApproach(treatmentApproaches);
-        DrugClassTreatmentApproach drugClassTreatmentApproach = extractOptionalDrugClassTreatmentApproach(treatmentApproaches);
+        writeTreatmentDrugClass(treatmentApproaches, id);
 
-        if (drugClassTreatmentApproach != null) {
-            writeTreatmentDrugClass(drugClassTreatmentApproach, id);
+        for (Reference reference : treatmentApproaches.references()) {
+            writeTreatmentReference(reference, id);
         }
 
-        if (therapyTreatmentApproach != null) {
-            writeTreatmentTherapy(therapyTreatmentApproach, id);
-        }
+        return id;
+    }
+
+    public int write(@NotNull TherapyTreatmentApproach treatmentApproaches) {
+        int id = context.insertInto(Treatmentapproach.TREATMENTAPPROACH,
+                        Treatmentapproach.TREATMENTAPPROACH.TREATMENTAPPROACHID,
+                        Treatmentapproach.TREATMENTAPPROACH.CREATEDATE,
+                        Treatmentapproach.TREATMENTAPPROACH.UPDATEDATE)
+                .values(treatmentApproaches.id(), treatmentApproaches.createDate(), treatmentApproaches.updateDate())
+                .returning(Treatmentapproach.TREATMENTAPPROACH.ID)
+                .fetchOne()
+                .getValue(Treatmentapproach.TREATMENTAPPROACH.ID);
+
+        writeTreatmentTherapy(treatmentApproaches, id);
 
         for (Reference reference : treatmentApproaches.references()) {
             writeTreatmentReference(reference, id);

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/Evidence.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/Evidence.java
@@ -5,7 +5,8 @@ import java.util.List;
 import com.hartwig.serve.ckb.datamodel.indication.Indication;
 import com.hartwig.serve.ckb.datamodel.reference.Reference;
 import com.hartwig.serve.ckb.datamodel.therapy.Therapy;
-import com.hartwig.serve.ckb.datamodel.treatmentapproaches.RelevantTreatmentApproaches;
+import com.hartwig.serve.ckb.datamodel.treatmentapproaches.DrugClassTreatmentApproach;
+import com.hartwig.serve.ckb.datamodel.treatmentapproaches.TherapyTreatmentApproach;
 
 import org.immutables.value.Value;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +28,10 @@ public abstract class Evidence {
     public abstract String responseType();
 
     @NotNull
-    public abstract List<RelevantTreatmentApproaches> relevantTreatmentApproaches();
+    public abstract List<DrugClassTreatmentApproach> drugTreatmentApproaches();
+
+    @NotNull
+    public abstract List<TherapyTreatmentApproach> therapyTreatmentApproaches();
 
     @NotNull
     public abstract String evidenceType();

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/EvidenceFactory.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/EvidenceFactory.java
@@ -26,7 +26,9 @@ public final class EvidenceFactory {
                     .therapy(TherapyFactory.resolveTherapy(ckbJsonDatabase, evidenceInfo.therapy()))
                     .indication(IndicationFactory.resolveIndication(ckbJsonDatabase, evidenceInfo.indication()))
                     .responseType(evidenceInfo.responseType())
-                    .relevantTreatmentApproaches(RelevantTreatmentApproachesFactory.extractRelevantTreatmentApproaches(ckbJsonDatabase,
+                    .drugTreatmentApproaches(RelevantTreatmentApproachesFactory.extractDrugTreatmentApproaches(ckbJsonDatabase,
+                            evidenceInfo.treatmentApproaches()))
+                    .therapyTreatmentApproaches(RelevantTreatmentApproachesFactory.extractTherapyTreatmentApproaches(ckbJsonDatabase,
                             evidenceInfo.treatmentApproaches()))
                     .evidenceType(evidenceInfo.evidenceType())
                     .efficacyEvidence(evidenceInfo.efficacyEvidence())

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/DrugClassTreatmentApproach.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/DrugClassTreatmentApproach.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Value.Immutable
 @Value.Style(passAnnotations = { NotNull.class, Nullable.class })
-public abstract class DrugClassTreatmentApproach implements TreatmentApproachIntervation{
+public abstract class DrugClassTreatmentApproach extends RelevantTreatmentApproaches{
 
     @NotNull
     public abstract DrugClass drugClass();

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/RelevantTreatmentApproaches.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/RelevantTreatmentApproaches.java
@@ -9,14 +9,9 @@ import org.immutables.value.Value;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@Value.Immutable
-@Value.Style(passAnnotations = { NotNull.class, Nullable.class })
 public abstract class RelevantTreatmentApproaches {
 
     public abstract int id();
-
-    @Nullable
-    public abstract TreatmentApproachIntervation treatmentApproachIntervation();
 
     @NotNull
     public abstract List<Reference> references();

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/TherapyTreatmentApproach.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/TherapyTreatmentApproach.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Value.Immutable
 @Value.Style(passAnnotations = { NotNull.class, Nullable.class })
-public abstract class TherapyTreatmentApproach implements TreatmentApproachIntervation{
+public abstract class TherapyTreatmentApproach extends RelevantTreatmentApproaches {
 
     @NotNull
     public abstract Therapy therapy();

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/TreatmentApproachIntervation.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/treatmentapproaches/TreatmentApproachIntervation.java
@@ -1,4 +1,0 @@
-package com.hartwig.serve.ckb.datamodel.treatmentapproaches;
-
-public interface TreatmentApproachIntervation {
-}


### PR DESCRIPTION
Does the following:
- Creates specific classes for drug and therapy based approaches
- Splits the collection into one drug collection and one therapy collection in the evidence.
- Moves the nullability check to one place, in the evidence creation when populating the two new collections.
- Use streams in the actionable evidence factory.

There is still some duplication that could be removed, I'll annotate it in the PR.