### PR TITLE
ACTIN-1571: Consolidate trials on NCT ID

### DIFF
--- a/algo/README.md
+++ b/algo/README.md
@@ -445,6 +445,8 @@ elsewhere.
 
 ## Version History and Download Links
 
+- Upcoming
+    - Actionable trials are consolidated by NCT ID per source.
 - [7.3.0](https://github.com/hartwigmedical/serve/releases/tag/serve-v7.3.0)
     - SQL SERVE database has been patched to v7.0.0 (separation of trial and efficacy evidence, multiple criteria per trial).
 - [7.2.0](https://github.com/hartwigmedical/serve/releases/tag/serve-v7.2.0)

--- a/algo/src/main/java/com/hartwig/serve/dao/DatabaseUtil.java
+++ b/algo/src/main/java/com/hartwig/serve/dao/DatabaseUtil.java
@@ -43,7 +43,7 @@ public final class DatabaseUtil {
         Set<String> formattedExcludedTypes =
                 indication.excludedSubTypes().stream().map(DatabaseUtil::formatCancerType).collect(Collectors.toSet());
         if (!formattedExcludedTypes.isEmpty()) {
-            addition = " excluding " + concat(formattedExcludedTypes);
+            addition = " (excluding " + concat(formattedExcludedTypes) + ")";
         }
         return base + addition;
     }

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -39,7 +39,7 @@ public final class ExtractionFunctions {
         Set<EventInterpretation> mergedInterpretations = Sets.newHashSet();
         ImmutableKnownEvents.Builder unconsolidatedKnownEventsBuilder = null;
         List<EfficacyEvidence> unconsolidatedEvidences = null;
-        List<ActionableTrial> mergedTrials = null;
+        List<ActionableTrial> unconsolidatedTrials = null;
 
         for (ExtractionResult result : results) {
             mergedInterpretations.addAll(result.eventInterpretations());
@@ -56,22 +56,21 @@ public final class ExtractionFunctions {
                 unconsolidatedEvidences.addAll(result.evidences());
             }
             if (result.trials() != null) {
-                if (mergedTrials == null) {
-                    mergedTrials = Lists.newArrayList();
+                if (unconsolidatedTrials == null) {
+                    unconsolidatedTrials = Lists.newArrayList();
                 }
-                mergedTrials.addAll(result.trials());
+                unconsolidatedTrials.addAll(result.trials());
             }
         }
 
         KnownEvents unconsolidatedKnownEvents = unconsolidatedKnownEventsBuilder != null ? unconsolidatedKnownEventsBuilder.build() : null;
 
-        // TODO (KD): We used to consolidate URLs for evidence in the past but not sure that is still necessary.
         return ImmutableExtractionResult.builder()
                 .refGenomeVersion(version)
                 .eventInterpretations(mergedInterpretations)
                 .knownEvents(consolidateKnownEvents(unconsolidatedKnownEvents))
                 .evidences(consolidateEvidences(unconsolidatedEvidences))
-                .trials(mergedTrials)
+                .trials(consolidateTrials(unconsolidatedTrials))
                 .build();
     }
 
@@ -131,6 +130,15 @@ public final class ExtractionFunctions {
             consolidatedEvents.add(ImmutableEfficacyEvidence.builder().from(entry.getKey()).urls(entry.getValue()).build());
         }
         return consolidatedEvents;
+    }
+
+    @Nullable
+    private static List<ActionableTrial> consolidateTrials(@Nullable List<ActionableTrial> unconsolidatedTrials) {
+        if (unconsolidatedTrials == null) {
+            return null;
+        }
+
+        return unconsolidatedTrials;
     }
 }
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -174,18 +174,16 @@ public final class ExtractionFunctions {
                 .countries(unique(trialsForSingleNctId.stream().map(ActionableTrial::countries)))
                 .therapyNames(unique(trialsForSingleNctId.stream().map(ActionableTrial::therapyNames)))
                 .genderCriterium(unique(trialsForSingleNctId.stream().map(ActionableTrial::genderCriterium)))
-                .indications(mergeSet(trialsForSingleNctId.stream().map(ActionableTrial::indications).collect(Collectors.toSet())))
-                .anyMolecularCriteria(mergeSet(trialsForSingleNctId.stream()
-                        .map(ActionableTrial::anyMolecularCriteria)
-                        .collect(Collectors.toSet())))
+                .indications(mergeSet(trialsForSingleNctId.stream().map(ActionableTrial::indications)))
+                .anyMolecularCriteria(mergeSet(trialsForSingleNctId.stream().map(ActionableTrial::anyMolecularCriteria)))
                 .urls(unique(trialsForSingleNctId.stream().map(ActionableTrial::urls)))
                 .build();
     }
 
     @NotNull
-    private static <T> Set<T> mergeSet(@NotNull Set<Set<T>> setOfSets) {
+    private static <T> Set<T> mergeSet(@NotNull Stream<Set<T>> streamOfSets) {
         Set<T> merged = new HashSet<>();
-        for (Set<T> set : setOfSets) {
+        for (Set<T> set : streamOfSets.collect(Collectors.toSet())) {
             merged.addAll(set);
         }
         return merged;

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -1,7 +1,6 @@
 package com.hartwig.serve.extraction;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -182,11 +181,7 @@ public final class ExtractionFunctions {
 
     @NotNull
     private static <T> Set<T> mergeSet(@NotNull Stream<Set<T>> streamOfSets) {
-        Set<T> merged = new HashSet<>();
-        for (Set<T> set : streamOfSets.collect(Collectors.toSet())) {
-            merged.addAll(set);
-        }
-        return merged;
+        return streamOfSets.flatMap(Set::stream).collect(Collectors.toSet());
     }
 
     @Nullable

--- a/algo/src/test/java/com/hartwig/serve/dao/DatabaseUtilTest.java
+++ b/algo/src/test/java/com/hartwig/serve/dao/DatabaseUtilTest.java
@@ -42,7 +42,7 @@ public class DatabaseUtilTest {
         CancerType excluded1 = DatamodelTestFactory.cancerTypeBuilder().name("excluded1").doid("doid").build();
         CancerType excluded2 = DatamodelTestFactory.cancerTypeBuilder().name("excluded2").doid("doid").build();
         Indication complex = withCancerTypeAndExcluded(applicable, excluded1, excluded2);
-        assertEquals("name (doid) excluding excluded1 (doid), excluded2 (doid)", DatabaseUtil.formatIndication(complex));
+        assertEquals("name (doid) (excluding excluded1 (doid), excluded2 (doid))", DatabaseUtil.formatIndication(complex));
     }
 
     @NotNull

--- a/algo/src/test/java/com/hartwig/serve/extraction/ExtractionFunctionsTest.java
+++ b/algo/src/test/java/com/hartwig/serve/extraction/ExtractionFunctionsTest.java
@@ -4,11 +4,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.Lists;
 import com.hartwig.serve.datamodel.Knowledgebase;
+import com.hartwig.serve.datamodel.common.DatamodelTestFactory;
+import com.hartwig.serve.datamodel.common.Indication;
 import com.hartwig.serve.datamodel.molecular.KnownEvent;
+import com.hartwig.serve.datamodel.molecular.MolecularCriterium;
+import com.hartwig.serve.datamodel.molecular.MolecularCriteriumTestFactory;
+import com.hartwig.serve.datamodel.trial.ActionableTrial;
+import com.hartwig.serve.datamodel.trial.TrialTestFactory;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
@@ -38,6 +45,88 @@ public class ExtractionFunctionsTest {
     }
 
     @Test
+    public void shouldConsolidateTrialsFromSingleSourceOnNctId() {
+        MolecularCriterium molecularCriterium1 = MolecularCriteriumTestFactory.createWithTestActionableCharacteristic();
+        MolecularCriterium molecularCriterium2 = MolecularCriteriumTestFactory.createWithTestActionableGene();
+        MolecularCriterium molecularCriterium3 = MolecularCriteriumTestFactory.createWithTestActionableHotspot();
+
+        Indication indication1 = DatamodelTestFactory.createTestIndication("applicable 1", "excluded 1");
+        Indication indication2 = DatamodelTestFactory.createTestIndication("applicable 2", "excluded 2");
+        Indication indication3 = DatamodelTestFactory.createTestIndication("applicable 3", "excluded 3");
+
+        ExtractionResult result1 = ImmutableExtractionResult.builder()
+                .from(ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1))
+                .trials(List.of(TrialTestFactory.builder()
+                        .source(SOURCE_1)
+                        .nctId("nct 1")
+                        .addIndications(indication1)
+                        .addAnyMolecularCriteria(molecularCriterium1)
+                        .build()))
+                .build();
+
+        ExtractionResult result2 = ImmutableExtractionResult.builder()
+                .from(ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1))
+                .trials(List.of(TrialTestFactory.builder()
+                        .source(SOURCE_1)
+                        .nctId("nct 1")
+                        .addIndications(indication2)
+                        .addAnyMolecularCriteria(molecularCriterium2)
+                        .build()))
+                .build();
+
+        ExtractionResult result3 = ImmutableExtractionResult.builder()
+                .from(ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1))
+                .trials(List.of(TrialTestFactory.builder()
+                        .source(SOURCE_1)
+                        .nctId("nct 2")
+                        .addIndications(indication3)
+                        .addAnyMolecularCriteria(molecularCriterium3)
+                        .build()))
+                .build();
+
+        ExtractionResult consolidated = ExtractionFunctions.merge(List.of(result1, result2, result3));
+
+        assertEquals(2, consolidated.trials().size());
+
+        ActionableTrial trial1 = findByNctId(consolidated.trials(), "nct 1");
+        assertEquals(2, trial1.indications().size());
+        assertTrue(trial1.indications().contains(indication1));
+        assertTrue(trial1.indications().contains(indication2));
+        assertEquals(2, trial1.anyMolecularCriteria().size());
+        assertTrue(trial1.anyMolecularCriteria().contains(molecularCriterium1));
+        assertTrue(trial1.anyMolecularCriteria().contains(molecularCriterium2));
+
+        ActionableTrial trial2 = findByNctId(consolidated.trials(), "nct 2");
+        assertEquals(1, trial2.indications().size());
+        assertTrue(trial2.indications().contains(indication3));
+        assertEquals(1, trial2.anyMolecularCriteria().size());
+        assertTrue(trial2.anyMolecularCriteria().contains(molecularCriterium3));
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void shouldThrowInCaseOfDifferentCountriesWithSameNctId() {
+        ExtractionResult result1 = ImmutableExtractionResult.builder()
+                .from(ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1))
+                .trials(List.of(TrialTestFactory.builder()
+                        .source(SOURCE_1)
+                        .nctId("nct 1")
+                        .addCountries(TrialTestFactory.countryBuilder().name("country 1").build())
+                        .build()))
+                .build();
+
+        ExtractionResult result2 = ImmutableExtractionResult.builder()
+                .from(ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1))
+                .trials(List.of(TrialTestFactory.builder()
+                        .source(SOURCE_1)
+                        .nctId("nct 1")
+                        .addCountries(TrialTestFactory.countryBuilder().name("country 2").build())
+                        .build()))
+                .build();
+
+        ExtractionFunctions.merge(List.of(result1, result2));
+    }
+
+    @Test
     public void retainsNullOnMinimalExtractionResults() {
         ExtractionResult result1 = ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_1);
         ExtractionResult result2 = ExtractionResultTestFactory.createMinimalResultForSource(SOURCE_2);
@@ -53,5 +142,10 @@ public class ExtractionFunctionsTest {
         KnownEvent first = known.iterator().next();
         assertTrue(first.sources().contains(SOURCE_1));
         assertTrue(first.sources().contains(SOURCE_2));
+    }
+
+    @NotNull
+    private static ActionableTrial findByNctId(@NotNull List<ActionableTrial> trials, @NotNull String nctIdToFind) {
+        return trials.stream().filter(trial -> trial.nctId().equals(nctIdToFind)).findFirst().orElseThrow();
     }
 }

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbExtractorTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbExtractorTest.java
@@ -103,20 +103,25 @@ public class CkbExtractorTest {
     @NotNull
     private static List<CkbEntry> createCkbEntryTestDatabase() {
         List<CkbEntry> ckbEntries = Lists.newArrayList();
-        ckbEntries.add(createWithOpenMolecularTrial("KIT", "amp", "KIT amp", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("BRAF", "V600E", "BRAF V600E", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("NTRK3", "fusion promiscuous", "NTRK3 fusion promiscuous", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("BRAF", "V600", "BRAF V600", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("BRAF", "exon 1 deletion", "BRAF exon 1 deletion", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("-", "MSI high", "MSI high", "sensitive", "Actionable"));
-        ckbEntries.add(createWithOpenMolecularTrial("ALK", "EML4-ALK", "EML4-ALK Fusion", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct1", "KIT", "amp", "KIT amp", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct2", "BRAF", "V600E", "BRAF V600E", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct3",
+                "NTRK3",
+                "fusion promiscuous",
+                "NTRK3 fusion promiscuous",
+                "sensitive",
+                "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct4", "BRAF", "V600", "BRAF V600", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct5", "BRAF", "exon 1 deletion", "BRAF exon 1 deletion", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct6", "-", "MSI high", "MSI high", "sensitive", "Actionable"));
+        ckbEntries.add(createWithOpenMolecularTrial("nct7", "ALK", "EML4-ALK", "EML4-ALK Fusion", "sensitive", "Actionable"));
 
         return ckbEntries;
     }
 
     @NotNull
-    private static CkbEntry createWithOpenMolecularTrial(@NotNull String gene, @NotNull String variant, @NotNull String fullName,
-            @NotNull String responseType, @NotNull String evidenceType) {
+    private static CkbEntry createWithOpenMolecularTrial(@NotNull String nctId, @NotNull String gene, @NotNull String variant,
+            @NotNull String fullName, @NotNull String responseType, @NotNull String evidenceType) {
         CkbEntry baseEntry = CkbTestFactory.createEntry(gene,
                 variant,
                 fullName,
@@ -130,7 +135,7 @@ public class CkbExtractorTest {
 
         return CkbTestFactory.builder()
                 .from(baseEntry)
-                .clinicalTrials(List.of(CkbTestFactory.createTrialWithTherapy("nctid",
+                .clinicalTrials(List.of(CkbTestFactory.createTrialWithTherapy(nctId,
                         "title",
                         List.of(CkbTestFactory.createTherapy("Nivolumab")),
                         List.of(CkbTestFactory.createIndication("test", "JAX:10000006")),


### PR DESCRIPTION
The result of this adjustment is that every NCT ID is unique _per source_. 

Since in practice we use one source for trials this detail doesn't matter too much.

Change has been verified in pilot (comparing ckb_pilot with actin_output_nl)

(Note: I have made some modifications to database loading in master, have tested these changes in pilot as well as part of this PR)