### PR TITLE
ACTIN-1702: Change varchar to text for countriesAndCities

### DIFF
--- a/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
+++ b/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
@@ -65,8 +65,7 @@ class ServeDAO {
         efficacyEvidenceDAO.write(serveRecord.evidences());
 
         LOGGER.info("Writing actionable trials");
-        String test = serveRecord.trials()
-                .get(0)
+        String test = serveRecord.trials().get(1)
                 .countries()
                 .stream()
                 .map(country -> country.name() + "(" + String.join(DatabaseUtil.SUB_JOINER, country.hospitalsPerCity().keySet()) + ")")

--- a/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
+++ b/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
@@ -1,6 +1,7 @@
 package com.hartwig.serve.dao;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.hartwig.serve.datamodel.ServeRecord;
 import com.hartwig.serve.extraction.events.EventInterpretation;
@@ -64,6 +65,13 @@ class ServeDAO {
         efficacyEvidenceDAO.write(serveRecord.evidences());
 
         LOGGER.info("Writing actionable trials");
+        String test = serveRecord.trials()
+                .get(0)
+                .countries()
+                .stream()
+                .map(country -> country.name() + "(" + String.join(DatabaseUtil.SUB_JOINER, country.hospitalsPerCity().keySet()) + ")")
+                .collect(Collectors.joining(DatabaseUtil.MAIN_JOINER));
+        LOGGER.info(test);
         actionableTrialDAO.write(serveRecord.trials());
     }
 }

--- a/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
+++ b/algo/src/main/java/com/hartwig/serve/dao/ServeDAO.java
@@ -1,7 +1,6 @@
 package com.hartwig.serve.dao;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.hartwig.serve.datamodel.ServeRecord;
 import com.hartwig.serve.extraction.events.EventInterpretation;
@@ -65,12 +64,6 @@ class ServeDAO {
         efficacyEvidenceDAO.write(serveRecord.evidences());
 
         LOGGER.info("Writing actionable trials");
-        String test = serveRecord.trials().get(1)
-                .countries()
-                .stream()
-                .map(country -> country.name() + "(" + String.join(DatabaseUtil.SUB_JOINER, country.hospitalsPerCity().keySet()) + ")")
-                .collect(Collectors.joining(DatabaseUtil.MAIN_JOINER));
-        LOGGER.info(test);
         actionableTrialDAO.write(serveRecord.trials());
     }
 }

--- a/algo/src/main/resources/database/generate_serve_db.sql
+++ b/algo/src/main/resources/database/generate_serve_db.sql
@@ -112,7 +112,7 @@ CREATE TABLE `actionableTrial`
     `nctId` varchar(20),
     `title` varchar(500),
     `acronym` varchar(100),
-    `countriesAndCities` varchar(50000),
+    `countriesAndCities` text,
     `hospitalsPerCity` text,
     `therapyNames` varchar(2000),
     `genderCriterium` varchar(50),

--- a/algo/src/main/resources/database/generate_serve_db.sql
+++ b/algo/src/main/resources/database/generate_serve_db.sql
@@ -112,7 +112,7 @@ CREATE TABLE `actionableTrial`
     `nctId` varchar(20),
     `title` varchar(500),
     `acronym` varchar(100),
-    `countriesAndCities` varchar(5000),
+    `countriesAndCities` varchar(10000),
     `hospitalsPerCity` text,
     `therapyNames` varchar(2000),
     `genderCriterium` varchar(50),

--- a/algo/src/main/resources/database/generate_serve_db.sql
+++ b/algo/src/main/resources/database/generate_serve_db.sql
@@ -112,7 +112,7 @@ CREATE TABLE `actionableTrial`
     `nctId` varchar(20),
     `title` varchar(500),
     `acronym` varchar(100),
-    `countriesAndCities` varchar(1000),
+    `countriesAndCities` varchar(5000),
     `hospitalsPerCity` text,
     `therapyNames` varchar(2000),
     `genderCriterium` varchar(50),

--- a/algo/src/main/resources/database/generate_serve_db.sql
+++ b/algo/src/main/resources/database/generate_serve_db.sql
@@ -112,7 +112,7 @@ CREATE TABLE `actionableTrial`
     `nctId` varchar(20),
     `title` varchar(500),
     `acronym` varchar(100),
-    `countriesAndCities` varchar(10000),
+    `countriesAndCities` varchar(50000),
     `hospitalsPerCity` text,
     `therapyNames` varchar(2000),
     `genderCriterium` varchar(50),


### PR DESCRIPTION
We get an error when loading the serve db indicating that the data is too long for the 'countriesAndCities' column. Tested in pilot and error is resolved.