### PR TITLE
ACTIN-1999: Actually apply the converted actionable hotspots when performing ref genome conversion

### DIFF
--- a/algo/README.md
+++ b/algo/README.md
@@ -447,6 +447,8 @@ elsewhere.
 
 ## Version History and Download Links
 
+- Upcoming
+  - Fix in SERVE ref genome conversion for actionable hotspots to actually apply the lifted-over hotspots in the conversion.
 - [8.3.0](https://github.com/hartwigmedical/serve/releases/tag/serve-v8.3.0)
     - Remove all variants from CKB with UNKNOWN protein impact when we map them to known events
 - [8.2.1](https://github.com/hartwigmedical/serve/releases/tag/serve-v8.2.1)

--- a/algo/src/test/java/com/hartwig/serve/refgenome/RefGenomeConverterTest.java
+++ b/algo/src/test/java/com/hartwig/serve/refgenome/RefGenomeConverterTest.java
@@ -1,6 +1,7 @@
 package com.hartwig.serve.refgenome;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -110,12 +111,12 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableHotspot> convertedActionableHotspotsFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().hotspots();
-        assertEquals(actionableHotspot, convertedActionableHotspotsFromEvidence.iterator().next());
+        assertNotSame(actionableHotspot, convertedActionableHotspotsFromEvidence.iterator().next());
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableHotspot> convertedActionableHotspotFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().hotspots();
-        assertEquals(actionableHotspot, convertedActionableHotspotFromTrial.iterator().next());
+        assertNotSame(actionableHotspot, convertedActionableHotspotFromTrial.iterator().next());
     }
 
     @Test
@@ -128,12 +129,12 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableCodonFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().codons();
-        assertEquals(actionableCodon, convertedActionableCodonFromEvidence.iterator().next());
+        assertNotSame(actionableCodon, convertedActionableCodonFromEvidence.iterator().next());
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableCodonFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().codons();
-        assertEquals(actionableCodon, convertedActionableCodonFromTrial.iterator().next());
+        assertNotSame(actionableCodon, convertedActionableCodonFromTrial.iterator().next());
     }
 
     @Test
@@ -146,12 +147,12 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableExonFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().exons();
-        assertEquals(actionableExon, convertedActionableExonFromEvidence.iterator().next());
+        assertNotSame(actionableExon, convertedActionableExonFromEvidence.iterator().next());
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableExonFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().exons();
-        assertEquals(actionableExon, convertedActionableExonFromTrial.iterator().next());
+        assertNotSame(actionableExon, convertedActionableExonFromTrial.iterator().next());
     }
 
     @NotNull

--- a/algo/src/test/java/com/hartwig/serve/refgenome/RefGenomeConverterTest.java
+++ b/algo/src/test/java/com/hartwig/serve/refgenome/RefGenomeConverterTest.java
@@ -111,12 +111,16 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableHotspot> convertedActionableHotspotsFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().hotspots();
-        assertNotSame(actionableHotspot, convertedActionableHotspotsFromEvidence.iterator().next());
+        ActionableHotspot convertedEvidenceHotspot = convertedActionableHotspotsFromEvidence.iterator().next();
+        assertNotSame(actionableHotspot, convertedEvidenceHotspot);
+        assertEquals(actionableHotspot, convertedEvidenceHotspot);
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableHotspot> convertedActionableHotspotFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().hotspots();
-        assertNotSame(actionableHotspot, convertedActionableHotspotFromTrial.iterator().next());
+        ActionableHotspot convertedTrialHotspot = convertedActionableHotspotFromTrial.iterator().next();
+        assertNotSame(actionableHotspot, convertedTrialHotspot);
+        assertEquals(actionableHotspot, convertedTrialHotspot);
     }
 
     @Test
@@ -129,12 +133,16 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableCodonFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().codons();
-        assertNotSame(actionableCodon, convertedActionableCodonFromEvidence.iterator().next());
+        ActionableRange convertedEvidenceCodon = convertedActionableCodonFromEvidence.iterator().next();
+        assertNotSame(actionableCodon, convertedEvidenceCodon);
+        assertEquals(actionableCodon, convertedEvidenceCodon);
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableCodonFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().codons();
-        assertNotSame(actionableCodon, convertedActionableCodonFromTrial.iterator().next());
+        ActionableRange convertedTrialCodon = convertedActionableCodonFromTrial.iterator().next();
+        assertNotSame(actionableCodon, convertedTrialCodon);
+        assertEquals(actionableCodon, convertedTrialCodon);
     }
 
     @Test
@@ -147,12 +155,16 @@ public class RefGenomeConverterTest {
         List<EfficacyEvidence> evidences = List.of(EfficacyEvidenceTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableExonFromEvidence =
                 DUMMY_CONVERTER.convertEfficacyEvidences(evidences).iterator().next().molecularCriterium().exons();
-        assertNotSame(actionableExon, convertedActionableExonFromEvidence.iterator().next());
+        ActionableRange convertedEvidenceExon = convertedActionableExonFromEvidence.iterator().next();
+        assertNotSame(actionableExon, convertedEvidenceExon);
+        assertEquals(actionableExon, convertedEvidenceExon);
 
         List<ActionableTrial> trials = List.of(TrialTestFactory.createWithMolecularCriterium(molecularCriterium));
         Set<ActionableRange> convertedActionableExonFromTrial =
                 DUMMY_CONVERTER.convertTrials(trials).iterator().next().anyMolecularCriteria().iterator().next().exons();
-        assertNotSame(actionableExon, convertedActionableExonFromTrial.iterator().next());
+        ActionableRange convertedTrialExon = convertedActionableExonFromTrial.iterator().next();
+        assertNotSame(actionableExon, convertedTrialExon);
+        assertEquals(actionableExon, convertedTrialExon);
     }
 
     @NotNull


### PR DESCRIPTION
Since `8.0.0` we no longer effectively convert actionable hotspots from one ref genome to another which is a pretty serious bug. 

I think this PR should fix it - currently running an exhaustive SERVE run on serve-vm-actin-1 VM, will be finished and checked tomorrow.