### PR TITLE
ACTIN-3199: Add ageGroups to evidence datamodels and filter on adult/senior evidence

### DIFF
--- a/algo/README.md
+++ b/algo/README.md
@@ -449,7 +449,7 @@ elsewhere.
 ## Version History and Download Links
 
 - [Upcoming]
-  - Add ageGroups to evidence datamodels
+  - Add ageGroups to evidence datamodels and filter on adult/senior evidence
 - [8.7.0](https://github.com/hartwigmedical/serve/releases/tag/8.7.0)
   - Add possibility to map CKB gene names
 - [8.6.0](https://github.com/hartwigmedical/serve/releases/tag/8.6.0)

--- a/algo/README.md
+++ b/algo/README.md
@@ -448,6 +448,8 @@ elsewhere.
 
 ## Version History and Download Links
 
+- [Upcoming]
+  - Add ageGroups to evidence datamodels
 - [8.7.0](https://github.com/hartwigmedical/serve/releases/tag/8.7.0)
   - Add possibility to map CKB gene names
 - [8.6.0](https://github.com/hartwigmedical/serve/releases/tag/8.6.0)

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableFunctions.java
@@ -1,5 +1,6 @@
 package com.hartwig.serve.sources.ckb;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -19,7 +20,23 @@ final class ActionableFunctions {
 
     private static final Logger LOGGER = LogManager.getLogger(ActionableFunctions.class);
 
+    private static final Set<String> AGE_GROUPS_TO_INCLUDE = Set.of("adult", "senior");
+
     private ActionableFunctions() {
+    }
+
+    @VisibleForTesting
+    static boolean hasAgeGroupToInclude(@NotNull List<String> ageGroups) {
+        if (ageGroups.isEmpty()) {
+            return true;
+        }
+
+        for (String age : ageGroups) {
+            if (AGE_GROUPS_TO_INCLUDE.contains(age.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Nullable

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/ActionableTrialFactory.java
@@ -1,5 +1,7 @@
 package com.hartwig.serve.sources.ckb;
 
+import static com.hartwig.serve.sources.ckb.ActionableFunctions.hasAgeGroupToInclude;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -48,8 +50,6 @@ class ActionableTrialFactory {
             "enrolling by invitation",
             "enrolling_by_invitation");
     private static final Set<String> VARIANT_REQUIREMENT_TYPES_TO_INCLUDE = Set.of("partial - required", "required");
-
-    private static final Set<String> AGE_GROUPS_TO_INCLUDE = Set.of("adult", "senior");
 
     private static final Set<String> DUTCH_CHILDREN_HOSPITALS = Set.of("PMC",
             "WKZ",
@@ -176,16 +176,6 @@ class ActionableTrialFactory {
             // (trial can be linked to multiple molecular profiles)
             if (entry.profileId() == variantRequirementDetail.profileId() && VARIANT_REQUIREMENT_TYPES_TO_INCLUDE.contains(
                     variantRequirementDetail.requirementType().toLowerCase())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @VisibleForTesting
-    static boolean hasAgeGroupToInclude(@NotNull List<String> ageGroups) {
-        for (String age : ageGroups) {
-            if (AGE_GROUPS_TO_INCLUDE.contains(age.toLowerCase())) {
                 return true;
             }
         }

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/EfficacyEvidenceFactory.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/EfficacyEvidenceFactory.java
@@ -1,5 +1,7 @@
 package com.hartwig.serve.sources.ckb;
 
+import static com.hartwig.serve.sources.ckb.ActionableFunctions.hasAgeGroupToInclude;
+
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
@@ -88,7 +90,7 @@ class EfficacyEvidenceFactory {
             @NotNull String combinedSourceEvent, @NotNull String combinedSourceGenes) {
         Set<EfficacyEvidence> efficacyEvidences = Sets.newHashSet();
 
-        for (Evidence evidence : evidencesWithUsableType(entry.evidences())) {
+        for (Evidence evidence : evidenceToInclude(entry.evidences())) {
             EvidenceLevelDetails evidenceLevelDetails = resolveEvidenceLevelDetails(evidence.approvalStatus());
             EvidenceDirection direction = resolveDirection(evidence.responseType());
             EvidenceLevel level = resolveLevel(evidence.ampCapAscoEvidenceLevel(), evidenceLevelDetails, direction);
@@ -168,10 +170,10 @@ class EfficacyEvidenceFactory {
     }
 
     @NotNull
-    private static List<Evidence> evidencesWithUsableType(@NotNull List<Evidence> evidences) {
+    private static List<Evidence> evidenceToInclude(@NotNull List<Evidence> evidences) {
         List<Evidence> filtered = Lists.newArrayList();
         for (Evidence evidence : evidences) {
-            if (hasUsableEvidenceType(evidence.evidenceType())) {
+            if (hasUsableEvidenceType(evidence.evidenceType()) && hasAgeGroupToInclude(evidence.ageGroups())) {
                 filtered.add(evidence);
             }
         }

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableFunctionsTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableFunctionsTest.java
@@ -32,6 +32,7 @@ public class ActionableFunctionsTest {
         assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Adult", "Child")));
         assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Child")));
         assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Adult")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of()));
     }
 
     @Test

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableFunctionsTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableFunctionsTest.java
@@ -1,10 +1,12 @@
 package com.hartwig.serve.sources.ckb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -15,6 +17,22 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class ActionableFunctionsTest {
+
+    @Test
+    public void hasAgeGroupToInclude() {
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("senior")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("adult")));
+        assertFalse(ActionableFunctions.hasAgeGroupToInclude(List.of("child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("senior", "adult", "child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("senior", "child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("senior", "adult")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Adult")));
+        assertFalse(ActionableFunctions.hasAgeGroupToInclude(List.of("Child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Adult", "Child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Child")));
+        assertTrue(ActionableFunctions.hasAgeGroupToInclude(List.of("Senior", "Adult")));
+    }
 
     @Test
     public void canExtractCancerTypeDetails() {

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/ActionableTrialFactoryTest.java
@@ -327,22 +327,6 @@ public class ActionableTrialFactoryTest {
     }
 
     @Test
-    public void hasAgeGroupToInclude() {
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("senior")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("adult")));
-        assertFalse(ActionableTrialFactory.hasAgeGroupToInclude(List.of("child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("senior", "adult", "child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("senior", "child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("senior", "adult")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Senior")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Adult")));
-        assertFalse(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Senior", "Adult", "Child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Senior", "Child")));
-        assertTrue(ActionableTrialFactory.hasAgeGroupToInclude(List.of("Senior", "Adult")));
-    }
-
-    @Test
     public void hasPotentiallyOpenRequirementToInclude() {
         assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("recruiting"));
         assertTrue(ActionableTrialFactory.hasPotentiallyOpenRequirementToInclude("not yet recruiting"));

--- a/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbTestFactory.java
+++ b/algo/src/test/java/com/hartwig/serve/sources/ckb/CkbTestFactory.java
@@ -163,6 +163,7 @@ public final class CkbTestFactory {
                 .approvalStatus(approvalStatus)
                 .ampCapAscoEvidenceLevel(level)
                 .ampCapAscoInferredTier("")
+                .ageGroups(List.of())
                 .references(List.of())
                 .build();
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/ClinicalTrialDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/ClinicalTrialDAO.java
@@ -1,7 +1,7 @@
 package com.hartwig.serve.ckb.dao;
 
-import com.hartwig.serve.ckb.database.tables.Agegroup;
 import com.hartwig.serve.ckb.database.tables.Clinicaltrial;
+import com.hartwig.serve.ckb.database.tables.Clinicaltrialagegroup;
 import com.hartwig.serve.ckb.database.tables.Contact;
 import com.hartwig.serve.ckb.database.tables.Indicationclinicaltrial;
 import com.hartwig.serve.ckb.database.tables.Location;
@@ -37,7 +37,7 @@ class ClinicalTrialDAO {
         context.deleteFrom(Location.LOCATION).execute();
 
         context.deleteFrom(Variantrequirementdetail.VARIANTREQUIREMENTDETAIL).execute();
-        context.deleteFrom(Agegroup.AGEGROUP).execute();
+        context.deleteFrom(Clinicaltrialagegroup.CLINICALTRIALAGEGROUP).execute();
 
         context.deleteFrom(Indicationclinicaltrial.INDICATIONCLINICALTRIAL).execute();
         context.deleteFrom(Therapyclinicaltrial.THERAPYCLINICALTRIAL).execute();
@@ -86,7 +86,7 @@ class ClinicalTrialDAO {
         }
 
         for (String ageGroup : clinicalTrial.ageGroups()) {
-            context.insertInto(Agegroup.AGEGROUP, Agegroup.AGEGROUP.CLINICALTRIALID, Agegroup.AGEGROUP.AGEGROUP_)
+            context.insertInto(Clinicaltrialagegroup.CLINICALTRIALAGEGROUP, Clinicaltrialagegroup.CLINICALTRIALAGEGROUP.CLINICALTRIALID, Clinicaltrialagegroup.CLINICALTRIALAGEGROUP.AGEGROUP)
                     .values(id, ageGroup)
                     .execute();
         }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
@@ -38,8 +38,8 @@ class EvidenceDAO {
         context.deleteFrom(Therapyevidence.THERAPYEVIDENCE).execute();
         context.deleteFrom(Indicationevidence.INDICATIONEVIDENCE).execute();
         context.deleteFrom(Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE).execute();
-        context.deleteFrom(Evidence.EVIDENCE).execute();
         context.deleteFrom(Evidenceagegroup.EVIDENCEAGEGROUP).execute();
+        context.deleteFrom(Evidence.EVIDENCE).execute();
     }
 
     public void write(@NotNull com.hartwig.serve.ckb.datamodel.evidence.Evidence evidence, int ckbEntryId) {

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
@@ -1,6 +1,7 @@
 package com.hartwig.serve.ckb.dao;
 
 import com.hartwig.serve.ckb.database.tables.Evidence;
+import com.hartwig.serve.ckb.database.tables.Evidenceagegroup;
 import com.hartwig.serve.ckb.database.tables.Evidencereference;
 import com.hartwig.serve.ckb.database.tables.Indicationevidence;
 import com.hartwig.serve.ckb.database.tables.Therapyevidence;
@@ -91,6 +92,12 @@ class EvidenceDAO {
                             Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE.EVIDENCEID,
                             Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE.TREATMENTAPPROACHEVIDENCEID)
                     .values(id, treatmentApproachId)
+                    .execute();
+        }
+
+        for (String ageGroup : evidence.ageGroups()) {
+            context.insertInto(Evidenceagegroup.EVIDENCEAGEGROUP, Evidenceagegroup.EVIDENCEAGEGROUP.EVIDENCEID, Evidenceagegroup.EVIDENCEAGEGROUP.AGEGROUP)
+                    .values(id, ageGroup)
                     .execute();
         }
 

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/dao/EvidenceDAO.java
@@ -39,6 +39,7 @@ class EvidenceDAO {
         context.deleteFrom(Indicationevidence.INDICATIONEVIDENCE).execute();
         context.deleteFrom(Treatmentapproachevidence.TREATMENTAPPROACHEVIDENCE).execute();
         context.deleteFrom(Evidence.EVIDENCE).execute();
+        context.deleteFrom(Evidenceagegroup.EVIDENCEAGEGROUP).execute();
     }
 
     public void write(@NotNull com.hartwig.serve.ckb.datamodel.evidence.Evidence evidence, int ckbEntryId) {

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/Evidence.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/Evidence.java
@@ -52,5 +52,8 @@ public abstract class Evidence {
     public abstract String ampCapAscoInferredTier();
 
     @NotNull
+    public abstract List<String> ageGroups();
+
+    @NotNull
     public abstract List<Reference> references();
 }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/EvidenceFactory.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/datamodel/evidence/EvidenceFactory.java
@@ -35,6 +35,7 @@ public final class EvidenceFactory {
                     .approvalStatus(evidenceInfo.approvalStatus())
                     .ampCapAscoEvidenceLevel(evidenceInfo.ampCapAscoEvidenceLevel())
                     .ampCapAscoInferredTier(evidenceInfo.ampCapAscoInferredTier())
+                    .ageGroups(evidenceInfo.ageGroups())
                     .references(ReferenceFactory.extractReferences(ckbJsonDatabase, evidenceInfo.references()))
                     .build());
         }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/common/EvidenceInfo.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/common/EvidenceInfo.java
@@ -46,5 +46,8 @@ public abstract class EvidenceInfo {
     public abstract String ampCapAscoInferredTier();
 
     @NotNull
+    public abstract List<String> ageGroups();
+
+    @NotNull
     public abstract List<TreatmentApproachInfo> treatmentApproaches();
 }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/drug/DrugDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/drug/DrugDatamodelChecker.java
@@ -108,6 +108,7 @@ final class DrugDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("DrugClinicalTrialTherapyObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/drug/DrugReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/drug/DrugReader.java
@@ -183,6 +183,7 @@ public class DrugReader extends CkbJsonDirectoryReader<JsonDrug> {
                     .references(extractEvidenceReferences(evidenceObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceObject, "ageGroups"))
                     .build());
         }
         return evidences;

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/gene/GeneDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/gene/GeneDatamodelChecker.java
@@ -94,6 +94,7 @@ final class GeneDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("GeneEvidenceObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/gene/GeneReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/gene/GeneReader.java
@@ -162,6 +162,7 @@ public class GeneReader extends CkbJsonDirectoryReader<JsonGene> {
                     .references(extractReferences(evidenceObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceObject, "ageGroups"))
                     .build());
         }
         return evidences;

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/indication/IndicationDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/indication/IndicationDatamodelChecker.java
@@ -44,6 +44,7 @@ final class IndicationDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("IndicationEvidenceObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/indication/IndicationReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/indication/IndicationReader.java
@@ -74,6 +74,7 @@ public class IndicationReader extends CkbJsonDirectoryReader<JsonIndication> {
                     .references(extractReferences(evidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceJsonObject, "ageGroups"))
                     .build());
         }
         return evidences;

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileDatamodelChecker.java
@@ -75,6 +75,7 @@ final class MolecularProfileDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
         map.put("relevantTreatmentApproaches", true);
 
         return new JsonDatamodelChecker("MolecularProfileComplexMolecularProfileEvidenceListObject", map);
@@ -154,6 +155,7 @@ final class MolecularProfileDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
         map.put("relevantTreatmentApproaches", true);
 
         return new JsonDatamodelChecker("MolecularProfileTreatmentApproachEvidenceListObject", map);
@@ -195,6 +197,7 @@ final class MolecularProfileDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
         map.put("relevantTreatmentApproaches", true);
 
         return new JsonDatamodelChecker("MolecularProfileVariantLevelEvidenceObject", map);
@@ -224,6 +227,7 @@ final class MolecularProfileDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("MolecularProfileExtendedEvidenceListObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileReader.java
@@ -243,6 +243,7 @@ public class MolecularProfileReader extends CkbJsonDirectoryReader<JsonMolecular
                     .references(extractReferences(treatmentApproachEvidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(treatmentApproachEvidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(treatmentApproachEvidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(treatmentApproachEvidenceJsonObject, "ageGroups"))
                     .treatmentApproaches(extractRelevantTreatmentApproaches(treatmentApproachEvidenceJsonObject.getAsJsonArray(
                             "relevantTreatmentApproaches")))
                     .build());
@@ -322,6 +323,7 @@ public class MolecularProfileReader extends CkbJsonDirectoryReader<JsonMolecular
                     .references(extractReferences(variantLevelEvidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(variantLevelEvidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(variantLevelEvidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(variantLevelEvidenceJsonObject, "ageGroups"))
                     .treatmentApproaches(extractRelevantTreatmentApproaches(variantLevelEvidenceJsonObject.getAsJsonArray(
                             "relevantTreatmentApproaches")))
                     .build());
@@ -362,6 +364,7 @@ public class MolecularProfileReader extends CkbJsonDirectoryReader<JsonMolecular
                     .references(extractReferences(extendedEvidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(extendedEvidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(extendedEvidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(extendedEvidenceJsonObject, "ageGroups"))
 
                     .build());
         }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/molecularprofile/MolecularProfileReader.java
@@ -131,6 +131,7 @@ public class MolecularProfileReader extends CkbJsonDirectoryReader<JsonMolecular
                     .references(extractReferences(complexMolecularProfileEvidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(complexMolecularProfileEvidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(complexMolecularProfileEvidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(complexMolecularProfileEvidenceJsonObject, "ageGroups"))
                     .treatmentApproaches(extractRelevantTreatmentApproaches(complexMolecularProfileEvidenceJsonObject.getAsJsonArray(
                             "relevantTreatmentApproaches")))
                     .build());

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/reference/ReferenceDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/reference/ReferenceDatamodelChecker.java
@@ -73,6 +73,7 @@ final class ReferenceDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("ReferenceEvidenceObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/reference/ReferenceReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/reference/ReferenceReader.java
@@ -124,6 +124,7 @@ public class ReferenceReader extends CkbJsonDirectoryReader<JsonReference> {
                     .references(extractReferences(evidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceJsonObject, "ageGroups"))
                     .build());
         }
 

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/therapy/TherapyDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/therapy/TherapyDatamodelChecker.java
@@ -64,6 +64,7 @@ final class TherapyDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("TherapyEvidenceObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/therapy/TherapyReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/therapy/TherapyReader.java
@@ -116,6 +116,7 @@ public class TherapyReader extends CkbJsonDirectoryReader<JsonTherapy> {
                     .references(extractReferences(evidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceJsonObject, "ageGroups"))
                     .build());
         }
         return evidences;

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantDatamodelChecker.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantDatamodelChecker.java
@@ -131,6 +131,7 @@ final class VariantDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("VariantEvidenceObject", map);
     }
@@ -180,6 +181,7 @@ final class VariantDatamodelChecker {
         map.put("references", true);
         map.put("ampCapAscoEvidenceLevel", true);
         map.put("ampCapAscoInferredTier", true);
+        map.put("ageGroups", true);
 
         return new JsonDatamodelChecker("VariantExtendedEvidenceObject", map);
     }

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantReader.java
@@ -278,6 +278,7 @@ public class VariantReader extends CkbJsonDirectoryReader<JsonVariant> {
                     .references(extractReferences(extendedEvidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(extendedEvidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(extendedEvidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(extendedEvidenceJsonObject, "ageGroups"))
                     .build());
         }
         return extendedEvidences;

--- a/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantReader.java
+++ b/ckb-importer/src/main/java/com/hartwig/serve/ckb/json/variant/VariantReader.java
@@ -216,6 +216,7 @@ public class VariantReader extends CkbJsonDirectoryReader<JsonVariant> {
                     .references(extractReferences(evidenceJsonObject.getAsJsonArray("references")))
                     .ampCapAscoEvidenceLevel(Json.string(evidenceJsonObject, "ampCapAscoEvidenceLevel"))
                     .ampCapAscoInferredTier(Json.string(evidenceJsonObject, "ampCapAscoInferredTier"))
+                    .ageGroups(Json.stringList(evidenceJsonObject, "ageGroups"))
                     .build());
         }
         return evidences;

--- a/ckb-importer/src/main/resources/database/generate_ckb_db.sql
+++ b/ckb-importer/src/main/resources/database/generate_ckb_db.sql
@@ -158,6 +158,7 @@ CREATE TABLE `evidence`
     `approvalStatus` varchar(50) NOT NULL,
     `ampCapAscoEvidenceLevel` varchar(50) NOT NULL,
     `ampCapAscoInferredTier` varchar(50) NOT NULL,
+    `ageGroups` varchar(50) NOT NULL,
     PRIMARY KEY (`id`),
     FOREIGN KEY (`ckbEntryId`) REFERENCES `ckbEntry`(`id`)
 );
@@ -377,8 +378,17 @@ CREATE TABLE `indicationClinicalTrial`
     FOREIGN KEY (`indicationId`) REFERENCES `indication`(`id`)
 );
 
-DROP TABLE IF EXISTS `ageGroup`;
-CREATE TABLE `ageGroup`
+DROP TABLE IF EXISTS `evidenceAgeGroup`;
+CREATE TABLE `evidenceAgeGroup`
+(   `id` int NOT NULL AUTO_INCREMENT,
+    `evidenceId` int NOT NULL,
+    `ageGroup` varchar(50) NOT NULL,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`evidenceId`) REFERENCES `evidence`(`id`)
+);
+
+DROP TABLE IF EXISTS `clinicalTrialAgeGroup`;
+CREATE TABLE `clinicalTrialAgeGroup`
 (   `id` int NOT NULL AUTO_INCREMENT,
     `clinicalTrialId` int NOT NULL,
     `ageGroup` varchar(50) NOT NULL,

--- a/ckb-importer/src/main/resources/database/generate_ckb_db.sql
+++ b/ckb-importer/src/main/resources/database/generate_ckb_db.sql
@@ -158,7 +158,6 @@ CREATE TABLE `evidence`
     `approvalStatus` varchar(50) NOT NULL,
     `ampCapAscoEvidenceLevel` varchar(50) NOT NULL,
     `ampCapAscoInferredTier` varchar(50) NOT NULL,
-    `ageGroups` varchar(50) NOT NULL,
     PRIMARY KEY (`id`),
     FOREIGN KEY (`ckbEntryId`) REFERENCES `ckbEntry`(`id`)
 );


### PR DESCRIPTION
CKB added new "ageGroups" field to their evidence datamodel