### PR TITLE
OPR-450: Bump java and maven versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2016-2025 hartwigmedical
+Copyright (C) 2016-2026 hartwigmedical
 
 GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007

--- a/algo/Dockerfile
+++ b/algo/Dockerfile
@@ -1,5 +1,6 @@
 # Pin to base image of eclipse-temurin that supports python2, needed for TransVar
-FROM eclipse-temurin:21-jre
-RUN apt-get update && apt-get install -fy unzip python-pip python2-dev zlib1g-dev libncurses5-dev
+FROM eclipse-temurin:21-jre-jammy@sha256:199aebeb3adcde4910695cdebfe782ada38dadb6cc8013159b58d3724451befd
+RUN apt-get update && apt-get install -fy unzip python2 python2-dev zlib1g-dev libncurses5-dev build-essential
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python2 get-pip.py
 RUN python2 -m pip install TransVar==2.3.4.20161215
 COPY ./target/algo-jar-with-dependencies.jar /opt/app/serve.jar

--- a/algo/Dockerfile
+++ b/algo/Dockerfile
@@ -1,6 +1,5 @@
 # Pin to base image of eclipse-temurin that supports python2, needed for TransVar
 FROM eclipse-temurin:21-jre-jammy@sha256:199aebeb3adcde4910695cdebfe782ada38dadb6cc8013159b58d3724451befd
-RUN apt-get update && apt-get install -fy unzip python2 python2-dev zlib1g-dev libncurses5-dev build-essential
-RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && python2 get-pip.py
+RUN apt-get update && apt-get install -fy unzip python2 python2-dev python-pip zlib1g-dev libncurses5-dev build-essential
 RUN python2 -m pip install TransVar==2.3.4.20161215
 COPY ./target/algo-jar-with-dependencies.jar /opt/app/serve.jar

--- a/algo/Dockerfile
+++ b/algo/Dockerfile
@@ -1,5 +1,5 @@
 # Pin to base image of eclipse-temurin that supports python2, needed for TransVar
-FROM eclipse-temurin:11-jre@sha256:7e474f2d1d3d1291c152d97ee3b9b6689b81e0d535326d8bfc680db35de0969b
+FROM eclipse-temurin:21-jre
 RUN apt-get update && apt-get install -fy unzip python-pip python2-dev zlib1g-dev libncurses5-dev
 RUN python2 -m pip install TransVar==2.3.4.20161215
 COPY ./target/algo-jar-with-dependencies.jar /opt/app/serve.jar

--- a/cloudbuild-pr.yaml
+++ b/cloudbuild-pr.yaml
@@ -12,7 +12,7 @@ steps:
       - path: '/cache/.m2'
         name: 'm2_cache'
   - id: 'Set release version'
-    name: 'maven:3.9.2-eclipse-temurin-11'
+    name: 'maven:3.9.12-eclipse-temurin-21'
     entrypoint: mvn
     args: [ 'versions:set', '-DnewVersion=${TAG_NAME}' ]
     volumes:
@@ -21,7 +21,7 @@ steps:
     env:
       - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
   - id: 'Compile, package, release'
-    name: 'maven:3.9.2-eclipse-temurin-11'
+    name: 'maven:3.9.12-eclipse-temurin-21'
     entrypoint: mvn
     args: [ 'test' ]
     volumes:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - path: '/cache/.m2'
         name: 'm2_cache'
   - id: 'Set release version'
-    name: 'maven:3.9.2-eclipse-temurin-11'
+    name: 'maven:3.9.12-eclipse-temurin-21'
     entrypoint: mvn
     args: [ 'versions:set', '-DnewVersion=${TAG_NAME}' ]
     volumes:
@@ -21,7 +21,7 @@ steps:
     env:
       - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
   - id: 'Compile, package, release'
-    name: 'maven:3.9.2-eclipse-temurin-11'
+    name: 'maven:3.9.12-eclipse-temurin-21'
     entrypoint: mvn
     args: [ 'deploy', '-B', '-DdeployAtEnd=true' ]
     volumes:

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <java.version>21</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        
+        <maven.compiler.release>21</maven.compiler.release>
 
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <java.version>21</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
-        <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
-        <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
+        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.assembly.plugin.version>3.6.0</maven.assembly.plugin.version>
+        <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
+        <maven.exec.plugin.version>3.5.0</maven.exec.plugin.version>
 
+        <google.artifactregistry.version>2.1.0</google.artifactregistry.version>
+        
         <commons.cli.version>1.3.1</commons.cli.version>
         <immutables.version>2.5.5</immutables.version>
         <htsjdk.version>2.23.0</htsjdk.version>
@@ -72,7 +75,7 @@
             <extension>
                 <groupId>com.google.cloud.artifactregistry</groupId>
                 <artifactId>artifactregistry-maven-wagon</artifactId>
-                <version>2.1.0</version>
+                <version>${google.artifactregistry.version}</version>
             </extension>
         </extensions>
         

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>


### PR DESCRIPTION
(Also bumped to the correct year in our LICENSE)

@kzuberihmf Would you know if java21 would work for SERVE given the docker we create to run transvar and which requires python2 (see `Dockerfile` in algo)? I will just give it a try but if you already know the answer or could provide guidance that would be appreciated!

UPDATE: All code looks good, cloud build works and currently running full regression run ([kd-20260615-3](https://console.cloud.google.com/batch/jobs?project=actin-shared))