### PR TITLE
ACTIN-3001: Remove config for full vs partial exonic delete

### DIFF
--- a/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionAnnotationConfig.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionAnnotationConfig.java
@@ -11,8 +11,6 @@ final class FusionAnnotationConfig {
 
     public static final Map<String, FusionPair> EXONIC_FUSIONS_MAP = exonicFusionMap();
 
-    public static final Map<String, ExonicDelDupType> DEL_DUP_TYPE_PER_GENE = exonicDelDupTypes();
-
     @NotNull
     private static Map<String, FusionPair> exonicFusionMap() {
         Map<String, FusionPair> map = Maps.newHashMap();
@@ -55,7 +53,7 @@ final class FusionAnnotationConfig {
                 .minExonDown(8)
                 .maxExonDown(8)
                 .build();
-        map.put("EGFRvIII", fusionEGFRvIII);
+        map.put("EGGRvIII", fusionEGFRvIII);
         map.put("VIII", fusionEGFRvIII);
 
         FusionPair fusionEGFRvV = ImmutableFusionPairImpl.builder()
@@ -69,21 +67,6 @@ final class FusionAnnotationConfig {
         map.put("EGFRvV", fusionEGFRvV);
 
         return map;
-    }
-
-    @NotNull
-    private static Map<String, ExonicDelDupType> exonicDelDupTypes() {
-        Map<String, ExonicDelDupType> exonicDelDupTypeMap = Maps.newHashMap();
-        exonicDelDupTypeMap.put("KIT", ExonicDelDupType.PARTIAL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("BRAF", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("CBL", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("EGFR", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("ERBB2", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("FGFR2", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("MET", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("MLH1", ExonicDelDupType.FULL_EXONIC_DELETION);
-        exonicDelDupTypeMap.put("PTEN", ExonicDelDupType.FULL_EXONIC_DELETION);
-        return exonicDelDupTypeMap;
     }
 
     private FusionAnnotationConfig() {

--- a/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionAnnotationConfig.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionAnnotationConfig.java
@@ -53,7 +53,7 @@ final class FusionAnnotationConfig {
                 .minExonDown(8)
                 .maxExonDown(8)
                 .build();
-        map.put("EGGRvIII", fusionEGFRvIII);
+        map.put("EGFRvIII", fusionEGFRvIII);
         map.put("VIII", fusionEGFRvIII);
 
         FusionPair fusionEGFRvV = ImmutableFusionPairImpl.builder()

--- a/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionExtractor.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionExtractor.java
@@ -64,12 +64,6 @@ public class FusionExtractor {
 
     @Nullable
     private static FusionPair fromExonicDelDup(@NotNull String gene, @NotNull String event) {
-        ExonicDelDupType exonicDelDupType = FusionAnnotationConfig.DEL_DUP_TYPE_PER_GENE.get(gene);
-        if (exonicDelDupType == null) {
-            LOGGER.warn("No exonic del dup type configured for gene '{}'", gene);
-            return null;
-        }
-
         Integer exonRankUp = null;
         Integer exonRankDown = null;
 
@@ -91,23 +85,8 @@ public class FusionExtractor {
             return null;
         }
 
-        int exonUp;
-        int exonDown;
-        switch (exonicDelDupType) {
-            case FULL_EXONIC_DELETION: {
-                exonUp = exonRankUp - 1;
-                exonDown = exonRankDown + 1;
-                break;
-            }
-            case PARTIAL_EXONIC_DELETION: {
-                exonUp = exonRankUp;
-                exonDown = exonRankDown;
-                break;
-            }
-            default: {
-                throw new IllegalStateException("Unrecognized del dup type: " + exonicDelDupType);
-            }
-        }
+        int exonUp = exonRankUp - 1;
+        int exonDown = exonRankDown + 1;
 
         return ImmutableFusionPairImpl.builder()
                 .geneUp(gene)

--- a/ckb-importer/src/test/java/com/hartwig/serve/ckb/classification/CkbEventTypeExtractorTest.java
+++ b/ckb-importer/src/test/java/com/hartwig/serve/ckb/classification/CkbEventTypeExtractorTest.java
@@ -28,5 +28,16 @@ public class CkbEventTypeExtractorTest {
         assertEquals(EventType.CHARACTERISTIC, CkbEventTypeExtractor.classify(CkbTestFactory.createEntry(characteristic)));
     }
     
+    @Test
+    public void canClassifyExonicFusions() {
+        Variant exonicFusion = CkbTestFactory.createVariant("TP53 del exon27", "del exon27", null);
+        assertEquals(EventType.FUSION_PAIR, CkbEventTypeExtractor.classify(CkbTestFactory.createEntry(exonicFusion)));
+    }
+
+    @Test
+    public void canClassifyExonicDeletes() {
+        Variant exonicDelete = CkbTestFactory.createVariant("TP53 exon 27 del", "exon 27 del", null);
+        assertEquals(EventType.EXON, CkbEventTypeExtractor.classify(CkbTestFactory.createEntry(exonicDelete)));
+    }
     
 }

--- a/ckb-importer/src/test/java/com/hartwig/serve/ckb/classification/CkbEventTypeExtractorTest.java
+++ b/ckb-importer/src/test/java/com/hartwig/serve/ckb/classification/CkbEventTypeExtractorTest.java
@@ -27,4 +27,6 @@ public class CkbEventTypeExtractorTest {
                 CkbTestFactory.createVariant(CkbConstants.NO_GENE, CkbConstants.MSI_NEGATIVE, CkbConstants.MSI_NEGATIVE, null);
         assertEquals(EventType.CHARACTERISTIC, CkbEventTypeExtractor.classify(CkbTestFactory.createEntry(characteristic)));
     }
+    
+    
 }


### PR DESCRIPTION
I've reviewed the impact of this change and I think this is all there is to it. The CKB events now get classified correctly (see updates to unit test for `CkbEventTypeExtractorTest`), and the only CKB event that is still configured as both an exonic delete as well as exonic fusion is `KIT exon 11`. 

With the removal of the config in this ticket this will always be assumed to be a full exonic delete, we simply don't support intra-exon fusions anymore (which are unlikely to be called anyways). 