### PR TITLE
OPR-468: Force deterministic order of events in SERVE output

### DIFF
--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -55,17 +55,21 @@ public final class ExtractionFunctions {
                 }
                 unconsolidatedKnownEventsBuilder.from(result.knownEvents());
             }
-            if (result.evidences() != null) {
+            
+            List<EfficacyEvidence> evidences = result.evidences();
+            if (evidences != null) {
                 if (unconsolidatedEvidences == null) {
                     unconsolidatedEvidences = Lists.newArrayList();
                 }
-                unconsolidatedEvidences.addAll(result.evidences());
+                unconsolidatedEvidences.addAll(evidences);
             }
-            if (result.trials() != null) {
+            
+            List<ActionableTrial> trials =  result.trials();
+            if (trials!= null) {
                 if (unconsolidatedTrials == null) {
                     unconsolidatedTrials = Lists.newArrayList();
                 }
-                unconsolidatedTrials.addAll(result.trials());
+                unconsolidatedTrials.addAll(trials);
             }
         }
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -151,7 +151,7 @@ public final class ExtractionFunctions {
             Set<String> uniqueNctIds = unconsolidatedTrials.stream()
                     .filter(trial -> trial.source() == source)
                     .map(ActionableTrial::nctId)
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(TreeSet::new));
 
             for (String nctId : uniqueNctIds) {
                 List<ActionableTrial> trialsForSingleNctId = unconsolidatedTrials.stream()

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -1,6 +1,7 @@
 package com.hartwig.serve.extraction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -124,7 +125,7 @@ public final class ExtractionFunctions {
             return null;
         }
 
-        Map<EfficacyEvidence, Set<String>> urlsPerEvidence = Maps.newLinkedHashMap();
+        Map<EfficacyEvidence, Set<String>> urlsPerEvidence = Maps.newHashMap();
         for (EfficacyEvidence evidence : unconsolidatedEvidences) {
             EfficacyEvidence stripped = ImmutableEfficacyEvidence.builder().from(evidence).urls(Set.of()).build();
             Set<String> urls = urlsPerEvidence.get(stripped);
@@ -139,6 +140,8 @@ public final class ExtractionFunctions {
         for (Map.Entry<EfficacyEvidence, Set<String>> entry : urlsPerEvidence.entrySet()) {
             consolidatedEvents.add(ImmutableEfficacyEvidence.builder().from(entry.getKey()).urls(entry.getValue()).build());
         }
+        
+        Collections.sort(consolidatedEvents);
         return consolidatedEvents;
     }
 
@@ -166,6 +169,7 @@ public final class ExtractionFunctions {
             }
         }
 
+        Collections.sort(consolidatedTrials);
         return consolidatedTrials;
     }
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -187,8 +187,8 @@ public final class ExtractionFunctions {
     }
 
     @NotNull
-    private static <T> Set<T> mergeSet(@NotNull Stream<Set<T>> streamOfSets) {
-        return streamOfSets.flatMap(Set::stream).collect(Collectors.toSet());
+    private static <T extends Comparable<T>> Set<T> mergeSet(@NotNull Stream<Set<T>> streamOfSets) {
+        return streamOfSets.flatMap(Set::stream).collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Nullable

--- a/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/ExtractionFunctions.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -119,7 +120,7 @@ public final class ExtractionFunctions {
             return null;
         }
 
-        Map<EfficacyEvidence, Set<String>> urlsPerEvidence = Maps.newHashMap();
+        Map<EfficacyEvidence, Set<String>> urlsPerEvidence = Maps.newLinkedHashMap();
         for (EfficacyEvidence evidence : unconsolidatedEvidences) {
             EfficacyEvidence stripped = ImmutableEfficacyEvidence.builder().from(evidence).urls(Set.of()).build();
             Set<String> urls = urlsPerEvidence.get(stripped);
@@ -144,7 +145,8 @@ public final class ExtractionFunctions {
         }
 
         List<ActionableTrial> consolidatedTrials = new ArrayList<>();
-        Set<Knowledgebase> sources = unconsolidatedTrials.stream().map(ActionableTrial::source).collect(Collectors.toSet());
+        Set<Knowledgebase> sources =
+                unconsolidatedTrials.stream().map(ActionableTrial::source).collect(Collectors.toCollection(TreeSet::new));
         for (Knowledgebase source : sources) {
             Set<String> uniqueNctIds = unconsolidatedTrials.stream()
                     .filter(trial -> trial.source() == source)

--- a/algo/src/main/java/com/hartwig/serve/extraction/codon/CodonConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/codon/CodonConsolidation.java
@@ -1,14 +1,17 @@
 package com.hartwig.serve.extraction.codon;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.range.ImmutableKnownCodon;
 import com.hartwig.serve.datamodel.molecular.range.KnownCodon;
+import com.hartwig.serve.datamodel.molecular.range.KnownCodonComparator;
 import com.hartwig.serve.extraction.util.ProteinEffectConsolidation;
 
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +23,7 @@ public final class CodonConsolidation {
 
     @NotNull
     public static Set<KnownCodon> consolidate(@NotNull Iterable<KnownCodon> codons) {
-        Map<KnownCodon, ConsolidatedData> dataPerConsolidatedCodon = Maps.newHashMap();
+        Map<KnownCodon, ConsolidatedData> dataPerConsolidatedCodon = new TreeMap<>(new KnownCodonComparator());
         for (KnownCodon codon : codons) {
             KnownCodon key = createKey(codon);
 
@@ -32,7 +35,7 @@ public final class CodonConsolidation {
             }
         }
 
-        Set<KnownCodon> consolidated = Sets.newHashSet();
+        Set<KnownCodon> consolidated = new TreeSet<>(new KnownCodonComparator());
         for (Map.Entry<KnownCodon, ConsolidatedData> entry : dataPerConsolidatedCodon.entrySet()) {
             ConsolidatedData consolidatedData = entry.getValue();
             consolidated.add(ImmutableKnownCodon.builder()
@@ -51,7 +54,7 @@ public final class CodonConsolidation {
 
     @NotNull
     private static ConsolidatedData merge(@NotNull ConsolidatedData data1, @NotNull ConsolidatedData data2) {
-        Set<Knowledgebase> sources = Sets.newHashSet();
+        Set<Knowledgebase> sources = EnumSet.noneOf(Knowledgebase.class);
         sources.addAll(data1.sources());
         sources.addAll(data2.sources());
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/copynumber/CopyNumberConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/copynumber/CopyNumberConsolidation.java
@@ -1,14 +1,17 @@
 package com.hartwig.serve.extraction.copynumber;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.gene.ImmutableKnownCopyNumber;
 import com.hartwig.serve.datamodel.molecular.gene.KnownCopyNumber;
+import com.hartwig.serve.datamodel.molecular.gene.KnownCopyNumberComparator;
 import com.hartwig.serve.extraction.util.ProteinEffectConsolidation;
 
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +23,7 @@ public final class CopyNumberConsolidation {
 
     @NotNull
     public static Set<KnownCopyNumber> consolidate(@NotNull Iterable<KnownCopyNumber> copyNumbers) {
-        Map<KnownCopyNumber, ConsolidatedData> dataPerConsolidatedCopyNumber = Maps.newHashMap();
+        Map<KnownCopyNumber, ConsolidatedData> dataPerConsolidatedCopyNumber = new TreeMap<>(new KnownCopyNumberComparator());
         for (KnownCopyNumber copyNumber : copyNumbers) {
             KnownCopyNumber key = createKey(copyNumber);
 
@@ -32,7 +35,7 @@ public final class CopyNumberConsolidation {
             }
         }
 
-        Set<KnownCopyNumber> consolidated = Sets.newHashSet();
+        Set<KnownCopyNumber> consolidated = new TreeSet<>(new KnownCopyNumberComparator());
         for (Map.Entry<KnownCopyNumber, ConsolidatedData> entry : dataPerConsolidatedCopyNumber.entrySet()) {
             ConsolidatedData consolidatedData = entry.getValue();
             consolidated.add(ImmutableKnownCopyNumber.builder()
@@ -51,7 +54,7 @@ public final class CopyNumberConsolidation {
 
     @NotNull
     private static ConsolidatedData merge(@NotNull ConsolidatedData data1, @NotNull ConsolidatedData data2) {
-        Set<Knowledgebase> sources = Sets.newHashSet();
+        Set<Knowledgebase> sources = EnumSet.noneOf(Knowledgebase.class);
         sources.addAll(data1.sources());
         sources.addAll(data2.sources());
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/exon/ExonConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/exon/ExonConsolidation.java
@@ -1,14 +1,17 @@
 package com.hartwig.serve.extraction.exon;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.range.ImmutableKnownExon;
 import com.hartwig.serve.datamodel.molecular.range.KnownExon;
+import com.hartwig.serve.datamodel.molecular.range.KnownExonComparator;
 import com.hartwig.serve.extraction.util.ProteinEffectConsolidation;
 
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +23,7 @@ public final class ExonConsolidation {
 
     @NotNull
     public static Set<KnownExon> consolidate(@NotNull Iterable<KnownExon> exons) {
-        Map<KnownExon, ConsolidatedData> dataPerConsolidatedExon = Maps.newHashMap();
+        Map<KnownExon, ConsolidatedData> dataPerConsolidatedExon = new TreeMap<>(new KnownExonComparator());
         for (KnownExon exon : exons) {
             KnownExon key = createKey(exon);
 
@@ -32,7 +35,7 @@ public final class ExonConsolidation {
             }
         }
 
-        Set<KnownExon> consolidated = Sets.newHashSet();
+        Set<KnownExon> consolidated = new TreeSet<>(new KnownExonComparator());
         for (Map.Entry<KnownExon, ConsolidatedData> entry : dataPerConsolidatedExon.entrySet()) {
             ConsolidatedData consolidatedData = entry.getValue();
             consolidated.add(ImmutableKnownExon.builder()
@@ -51,7 +54,7 @@ public final class ExonConsolidation {
 
     @NotNull
     private static ConsolidatedData merge(@NotNull ConsolidatedData data1, @NotNull ConsolidatedData data2) {
-        Set<Knowledgebase> sources = Sets.newHashSet();
+        Set<Knowledgebase> sources = EnumSet.noneOf(Knowledgebase.class);
         sources.addAll(data1.sources());
         sources.addAll(data2.sources());
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/fusion/FusionConsolidation.java
@@ -1,14 +1,17 @@
 package com.hartwig.serve.extraction.fusion;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.fusion.ImmutableKnownFusion;
 import com.hartwig.serve.datamodel.molecular.fusion.KnownFusion;
+import com.hartwig.serve.datamodel.molecular.fusion.KnownFusionComparator;
 import com.hartwig.serve.extraction.util.ProteinEffectConsolidation;
 
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +23,7 @@ public final class FusionConsolidation {
 
     @NotNull
     public static Set<KnownFusion> consolidate(@NotNull Iterable<KnownFusion> fusions) {
-        Map<KnownFusion, ConsolidatedData> dataPerConsolidatedFusion = Maps.newHashMap();
+        Map<KnownFusion, ConsolidatedData> dataPerConsolidatedFusion = new TreeMap<>(new KnownFusionComparator());
         for (KnownFusion fusion : fusions) {
             KnownFusion key = createKey(fusion);
 
@@ -32,7 +35,7 @@ public final class FusionConsolidation {
             }
         }
 
-        Set<KnownFusion> consolidated = Sets.newHashSet();
+        Set<KnownFusion> consolidated = new TreeSet<>(new KnownFusionComparator());
         for (Map.Entry<KnownFusion, ConsolidatedData> entry : dataPerConsolidatedFusion.entrySet()) {
             ConsolidatedData consolidatedData = entry.getValue();
             consolidated.add(ImmutableKnownFusion.builder()
@@ -51,7 +54,7 @@ public final class FusionConsolidation {
 
     @NotNull
     private static ConsolidatedData merge(@NotNull ConsolidatedData data1, @NotNull ConsolidatedData data2) {
-        Set<Knowledgebase> sources = Sets.newHashSet();
+        Set<Knowledgebase> sources = EnumSet.noneOf(Knowledgebase.class);
         sources.addAll(data1.sources());
         sources.addAll(data2.sources());
 

--- a/algo/src/main/java/com/hartwig/serve/extraction/gene/GeneConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/gene/GeneConsolidation.java
@@ -3,13 +3,16 @@ package com.hartwig.serve.extraction.gene;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 import static java.util.stream.StreamSupport.stream;
 
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import com.hartwig.serve.datamodel.molecular.gene.ImmutableKnownGene;
 import com.hartwig.serve.datamodel.molecular.gene.KnownGene;
+import com.hartwig.serve.datamodel.molecular.gene.KnownGeneComparator;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -20,11 +23,13 @@ public final class GeneConsolidation {
 
     @NotNull
     public static Set<KnownGene> consolidate(@NotNull Iterable<KnownGene> genes) {
-        return stream(genes.spliterator(), false).collect(groupingBy(gene -> ImmutableKnownGene.copyOf(gene).withSources(emptySet())))
+        return stream(genes.spliterator(), false).collect(groupingBy(gene -> ImmutableKnownGene.copyOf(gene).withSources(emptySet()),
+                        () -> new TreeMap<>(new KnownGeneComparator()),
+                        toList()))
                 .entrySet()
                 .stream()
                 .map(entry -> ImmutableKnownGene.copyOf(entry.getKey())
                         .withSources(entry.getValue().stream().flatMap(gene -> gene.sources().stream()).collect(toList())))
-                .collect(toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownGeneComparator())));
     }
 }

--- a/algo/src/main/java/com/hartwig/serve/extraction/variant/KnownHotspotConsolidation.java
+++ b/algo/src/main/java/com/hartwig/serve/extraction/variant/KnownHotspotConsolidation.java
@@ -1,14 +1,17 @@
 package com.hartwig.serve.extraction.variant;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.hartwig.serve.datamodel.Knowledgebase;
 import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.hotspot.ImmutableKnownHotspot;
 import com.hartwig.serve.datamodel.molecular.hotspot.KnownHotspot;
+import com.hartwig.serve.datamodel.molecular.hotspot.KnownHotspotComparator;
 import com.hartwig.serve.extraction.util.ProteinEffectConsolidation;
 
 import org.apache.logging.log4j.util.Strings;
@@ -22,7 +25,7 @@ public final class KnownHotspotConsolidation {
 
     @NotNull
     public static Set<KnownHotspot> consolidate(@NotNull Iterable<KnownHotspot> hotspots) {
-        Map<KnownHotspot, ConsolidatedData> dataPerConsolidatedHotspot = Maps.newHashMap();
+        Map<KnownHotspot, ConsolidatedData> dataPerConsolidatedHotspot = new TreeMap<>(new KnownHotspotComparator());
         for (KnownHotspot hotspot : hotspots) {
             KnownHotspot key = createKey(hotspot);
 
@@ -34,7 +37,7 @@ public final class KnownHotspotConsolidation {
             }
         }
 
-        Set<KnownHotspot> consolidatedHotspots = Sets.newHashSet();
+        Set<KnownHotspot> consolidatedHotspots = new TreeSet<>(new KnownHotspotComparator());
         for (Map.Entry<KnownHotspot, ConsolidatedData> entry : dataPerConsolidatedHotspot.entrySet()) {
             ConsolidatedData consolidatedData = entry.getValue();
             consolidatedHotspots.add(ImmutableKnownHotspot.builder()
@@ -93,7 +96,7 @@ public final class KnownHotspotConsolidation {
             bestProteinAnnotation = favorAnnotation1 ? data1.inputProteinAnnotation() : data2.inputProteinAnnotation();
         }
 
-        Set<Knowledgebase> mergedSources = Sets.newHashSet();
+        Set<Knowledgebase> mergedSources = EnumSet.noneOf(Knowledgebase.class);
         mergedSources.addAll(data1.sources());
         mergedSources.addAll(data2.sources());
 

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/CkbKnownEventsExtractor.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/CkbKnownEventsExtractor.java
@@ -6,6 +6,7 @@ import static com.hartwig.serve.sources.ckb.CkbVariantAnnotator.resolveGeneRole;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -24,18 +25,24 @@ import com.hartwig.serve.datamodel.molecular.common.ProteinEffect;
 import com.hartwig.serve.datamodel.molecular.fusion.FusionPair;
 import com.hartwig.serve.datamodel.molecular.fusion.ImmutableKnownFusion;
 import com.hartwig.serve.datamodel.molecular.fusion.KnownFusion;
+import com.hartwig.serve.datamodel.molecular.fusion.KnownFusionComparator;
 import com.hartwig.serve.datamodel.molecular.gene.GeneAnnotation;
 import com.hartwig.serve.datamodel.molecular.gene.ImmutableKnownCopyNumber;
 import com.hartwig.serve.datamodel.molecular.gene.ImmutableKnownGene;
 import com.hartwig.serve.datamodel.molecular.gene.KnownCopyNumber;
+import com.hartwig.serve.datamodel.molecular.gene.KnownCopyNumberComparator;
 import com.hartwig.serve.datamodel.molecular.gene.KnownGene;
+import com.hartwig.serve.datamodel.molecular.gene.KnownGeneComparator;
 import com.hartwig.serve.datamodel.molecular.hotspot.ImmutableKnownHotspot;
 import com.hartwig.serve.datamodel.molecular.hotspot.KnownHotspot;
+import com.hartwig.serve.datamodel.molecular.hotspot.KnownHotspotComparator;
 import com.hartwig.serve.datamodel.molecular.hotspot.VariantAnnotation;
 import com.hartwig.serve.datamodel.molecular.range.ImmutableKnownCodon;
 import com.hartwig.serve.datamodel.molecular.range.ImmutableKnownExon;
 import com.hartwig.serve.datamodel.molecular.range.KnownCodon;
+import com.hartwig.serve.datamodel.molecular.range.KnownCodonComparator;
 import com.hartwig.serve.datamodel.molecular.range.KnownExon;
+import com.hartwig.serve.datamodel.molecular.range.KnownExonComparator;
 import com.hartwig.serve.extraction.codon.CodonAnnotation;
 import com.hartwig.serve.extraction.codon.CodonConsolidation;
 import com.hartwig.serve.extraction.copynumber.CopyNumberConsolidation;
@@ -53,28 +60,28 @@ final class CkbKnownEventsExtractor {
     public static KnownEvents generateKnownEvents(@NotNull List<ExtractedEvent> allEvents) {
         Set<KnownHotspot> allHotspots = allEvents.stream()
                 .flatMap(event -> convertToKnownHotspots(event.eventExtractorOutput().variants(), event.event(), event.variant()).stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownHotspotComparator())));
 
         Set<KnownCodon> allCodons = allEvents.stream()
                 .flatMap(event -> convertToKnownCodons(event.eventExtractorOutput().codons(), event.variant()).stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownCodonComparator())));
 
         Set<KnownExon> allExons = allEvents.stream()
                 .flatMap(event -> convertToKnownExons(event.eventExtractorOutput().exons(), event.variant()).stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownExonComparator())));
 
         Set<KnownGene> allGenes = allEvents.stream()
                 .flatMap(event -> event.eventExtractorOutput().fusionPair() == null ? convertToKnownGenes(event.gene(),
                         event.variant()).stream() : Stream.empty())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownGeneComparator())));
 
         Set<KnownCopyNumber> allCopyNumbers = allEvents.stream()
                 .flatMap(event -> convertToKnownCopyNumbers(event.eventExtractorOutput().copyNumber(), event.variant()).stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownCopyNumberComparator())));
 
         Set<KnownFusion> allFusions = allEvents.stream()
                 .flatMap(event -> convertToKnownFusions(event.eventExtractorOutput().fusionPair(), event.variant()).stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(() -> new TreeSet<>(new KnownFusionComparator())));
 
         return ImmutableKnownEvents.builder()
                 .hotspots(allHotspots)
@@ -181,12 +188,10 @@ final class CkbKnownEventsExtractor {
         }
         Set<U> converted = rawList.stream().map(convert).collect(Collectors.toSet());
         return consolidate.apply(converted).stream().map(e -> annotate.apply(e, variant)).filter(event -> {
-            if (event instanceof GeneAlteration) {
-                GeneAlteration alteration = (GeneAlteration) event;
+            if (event instanceof GeneAlteration alteration) {
                 return alteration.proteinEffect() != ProteinEffect.UNKNOWN
                         || Boolean.TRUE.equals(alteration.associatedWithDrugResistance());
-            } else if (event instanceof KnownFusion) {
-                KnownFusion fusion = (KnownFusion) event;
+            } else if (event instanceof KnownFusion fusion) {
                 return fusion.proteinEffect() != ProteinEffect.UNKNOWN || Boolean.TRUE.equals(fusion.associatedWithDrugResistance());
             }
             LOGGER.warn("{} is not a GeneAlteration or KnownFusion", event.getClass().toString());

--- a/algo/src/main/java/com/hartwig/serve/sources/ckb/CkbMolecularCriteriaExtractor.java
+++ b/algo/src/main/java/com/hartwig/serve/sources/ckb/CkbMolecularCriteriaExtractor.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -122,7 +123,7 @@ final class CkbMolecularCriteriaExtractor {
         return Stream.of(extractionOutput.geneLevel(), extractionOutput.copyNumber())
                 .filter(Objects::nonNull)
                 .map(annotation -> extractActionableGenes(annotation, actionableEvent))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @NotNull
@@ -148,7 +149,7 @@ final class CkbMolecularCriteriaExtractor {
             @NotNull ActionableEvent actionableEvent) {
         return ranges.stream()
                 .map(range -> ImmutableActionableRange.builder().from(range).from(actionableEvent).build())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @NotNull

--- a/datamodel/src/main/java/com/hartwig/serve/datamodel/serialization/ServeJson.java
+++ b/datamodel/src/main/java/com/hartwig/serve/datamodel/serialization/ServeJson.java
@@ -35,14 +35,14 @@ import org.jetbrains.annotations.NotNull;
 public final class ServeJson {
 
     private static final JsonMapper MAPPER = JsonMapper.builder()
+            // KD: Note - the sorting that is done here may be unnecessary/obsolete 
+            // since the code that generates the datamodel already fixes sorting
             .addModule(new JavaTimeModule())
-            .addModule(new SimpleModule()
-                    .addSerializer(LocalDate.class, new LocalDateSerializer())
+            .addModule(new SimpleModule().addSerializer(LocalDate.class, new LocalDateSerializer())
                     .addDeserializer(LocalDate.class, new LocalDateDeserializer())
                     .addSerializer(Set.class, new SortedSetJsonSerializer())
                     .addSerializer(Map.class, new SortedMapJsonSerializer())
-                    .addSerializer(List.class, new SortedListJsonSerializer())
-            )
+                    .addSerializer(List.class, new SortedListJsonSerializer()))
             .serializationInclusion(JsonInclude.Include.NON_NULL)
             .build();
 

--- a/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
+++ b/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
@@ -1,7 +1,10 @@
 package com.hartwig.serve.datamodel.util;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,8 +15,11 @@ public final class CompareFunctions {
     }
 
     public static <T extends Comparable<T>> int compareSetOfComparable(@NotNull Set<T> set1, @NotNull Set<T> set2) {
-        Iterator<T> set1Iterator = set1.iterator();
-        Iterator<T> set2Iterator = set2.iterator();
+        SortedSet<T> sorted1 = new TreeSet<>(set1);
+        SortedSet<T> sorted2 = new TreeSet<>(set2);
+        
+        Iterator<T> set1Iterator = sorted1.iterator();
+        Iterator<T> set2Iterator = sorted2.iterator();
 
         while (set1Iterator.hasNext() && set2Iterator.hasNext()) {
             int entryCompare = set1Iterator.next().compareTo(set2Iterator.next());
@@ -22,7 +28,7 @@ public final class CompareFunctions {
             }
         }
 
-        return Integer.compare(set2.size(), set1.size());
+        return Integer.compare(sorted2.size(), sorted1.size());
     }
 
     public static int compareNullableStrings(@Nullable String string1, @Nullable String string2) {

--- a/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
+++ b/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
@@ -2,8 +2,6 @@ package com.hartwig.serve.datamodel.util;
 
 import java.util.Iterator;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,11 +12,9 @@ public final class CompareFunctions {
     }
 
     public static <T extends Comparable<T>> int compareSetOfComparable(@NotNull Set<T> set1, @NotNull Set<T> set2) {
-        SortedSet<T> sorted1 = new TreeSet<>(set1);
-        SortedSet<T> sorted2 = new TreeSet<>(set2);
-        
-        Iterator<T> set1Iterator = sorted1.iterator();
-        Iterator<T> set2Iterator = sorted2.iterator();
+        // KD: This function assumes that sets are sorted, and if not, then there is a specific reason for by the caller of this function
+        Iterator<T> set1Iterator = set1.iterator();
+        Iterator<T> set2Iterator = set2.iterator();
 
         while (set1Iterator.hasNext() && set2Iterator.hasNext()) {
             int entryCompare = set1Iterator.next().compareTo(set2Iterator.next());
@@ -27,7 +23,7 @@ public final class CompareFunctions {
             }
         }
 
-        return Integer.compare(sorted1.size(), sorted2.size());
+        return Integer.compare(set1.size(), set2.size());
     }
 
     public static int compareNullableStrings(@Nullable String string1, @Nullable String string2) {

--- a/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
+++ b/datamodel/src/main/java/com/hartwig/serve/datamodel/util/CompareFunctions.java
@@ -1,7 +1,6 @@
 package com.hartwig.serve.datamodel.util;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -28,7 +27,7 @@ public final class CompareFunctions {
             }
         }
 
-        return Integer.compare(sorted2.size(), sorted1.size());
+        return Integer.compare(sorted1.size(), sorted2.size());
     }
 
     public static int compareNullableStrings(@Nullable String string1, @Nullable String string2) {

--- a/datamodel/src/main/java/com/hartwig/serve/datamodel/util/MolecularCriteriumCombiner.java
+++ b/datamodel/src/main/java/com/hartwig/serve/datamodel/util/MolecularCriteriumCombiner.java
@@ -2,6 +2,7 @@ package com.hartwig.serve.datamodel.util;
 
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,7 +32,7 @@ public final class MolecularCriteriumCombiner {
     }
 
     @NotNull
-    private static <T> Set<T> union(@NotNull Set<T> set1, @NotNull Set<T> set2) {
-        return Stream.concat(set1.stream(), set2.stream()).collect(Collectors.toSet());
+    private static <T extends Comparable<T>> Set<T> union(@NotNull Set<T> set1, @NotNull Set<T> set2) {
+        return Stream.concat(set1.stream(), set2.stream()).collect(Collectors.toCollection(TreeSet::new));
     }
 }

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/efficacy/EfficacyEvidenceComparatorTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/efficacy/EfficacyEvidenceComparatorTest.java
@@ -7,13 +7,18 @@ import java.util.Collections;
 import java.util.List;
 
 import com.hartwig.serve.datamodel.Knowledgebase;
+import com.hartwig.serve.datamodel.molecular.ImmutableMolecularCriterium;
+import com.hartwig.serve.datamodel.molecular.fusion.ActionableFusion;
+import com.hartwig.serve.datamodel.molecular.fusion.FusionTestFactory;
+import com.hartwig.serve.datamodel.molecular.gene.ActionableGene;
+import com.hartwig.serve.datamodel.molecular.gene.GeneTestFactory;
 
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class EfficacyEvidenceComparatorTest {
-
+    
     @Test
     public void canSortEfficacyEvidences() {
         EfficacyEvidence evidence1 = create("CancerA", EvidenceLevel.A, EvidenceLevelDetails.CLINICAL_STUDY, EvidenceDirection.RESPONSIVE);
@@ -30,18 +35,47 @@ public class EfficacyEvidenceComparatorTest {
         assertEquals(evidence4, efficacyEvidences.get(3));
     }
 
+    @Test
+    public void canSortEfficacyEvidenceWithCombinedMolecularProfile() {
+        ActionableGene testGene1 = GeneTestFactory.createTestActionableGene();
+        ActionableGene testGene2 = GeneTestFactory.createTestActionableGene();
+        ActionableFusion testFusion = FusionTestFactory.createTestActionableFusion();
+
+        EfficacyEvidence evidence1 = EfficacyEvidenceTestFactory.builder()
+                .efficacyDescription("description 2")
+                .molecularCriterium(ImmutableMolecularCriterium.builder()
+                        .addGenes(testGene1)
+                        .addGenes(testGene2)
+                        .build())
+                .build();
+        
+        EfficacyEvidence evidence2 = EfficacyEvidenceTestFactory.builder()
+                .efficacyDescription("description 1")
+                .molecularCriterium(ImmutableMolecularCriterium.builder()
+                        .addGenes(testGene1)
+                        .addGenes(testGene2)
+                        .addFusions(testFusion)
+                        .build())
+                .build();
+
+
+        List<EfficacyEvidence> efficacyEvidences = new ArrayList<>(List.of(evidence1, evidence2));
+        efficacyEvidences.sort(new EfficacyEvidenceComparator());
+
+        assertEquals(evidence1, efficacyEvidences.get(0));
+        assertEquals(evidence2, efficacyEvidences.get(1));
+    }
+
     @NotNull
     private static EfficacyEvidence create(@NotNull String applicableCancerType, @NotNull EvidenceLevel evidenceLevel,
             @NotNull EvidenceLevelDetails evidenceLevelDetails, @NotNull EvidenceDirection evidenceDirection) {
-        return EfficacyEvidenceTestFactory.createTestEfficacyEvidence(
-            Knowledgebase.UNKNOWN,
-            applicableCancerType,
-            Strings.EMPTY,
-            evidenceLevel,
-            evidenceLevelDetails,
-            evidenceDirection,
-            2024,
-            Collections.emptySet()
-        );
+        return EfficacyEvidenceTestFactory.createTestEfficacyEvidence(Knowledgebase.UNKNOWN,
+                applicableCancerType,
+                Strings.EMPTY,
+                evidenceLevel,
+                evidenceLevelDetails,
+                evidenceDirection,
+                2024,
+                Collections.emptySet());
     }
 }

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/ActionableEventComparatorTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/ActionableEventComparatorTest.java
@@ -16,8 +16,8 @@ public class ActionableEventComparatorTest {
     @Test
     public void canSortActionableEvents() {
         ActionableEvent actionableEvent1 = create(LocalDate.of(2024, 1, 1), "event 1", createUrls("url 1", "url 2"));
-        ActionableEvent actionableEvent2 = create(LocalDate.of(2023, 1, 1), "event 1", createUrls("url 1", "url 2"));
-        ActionableEvent actionableEvent3 = create(LocalDate.of(2023, 1, 1), "event 1", createUrls("url 1"));
+        ActionableEvent actionableEvent2 = create(LocalDate.of(2023, 1, 1), "event 1", createUrls("url 1"));
+        ActionableEvent actionableEvent3 = create(LocalDate.of(2023, 1, 1), "event 1", createUrls("url 1", "url 2"));
         ActionableEvent actionableEvent4 = create(LocalDate.of(2024, 1, 1), "event 2", createUrls("url 1", "url 2"));
 
         List<ActionableEvent> actionableEvents = new ArrayList<>(

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/MolecularCriteriumComparatorTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/MolecularCriteriumComparatorTest.java
@@ -11,9 +11,9 @@ public class MolecularCriteriumComparatorTest {
 
     @Test
     public void canSortMolecularCriteria() {
-        MolecularCriterium criterium1 = MolecularCriteriumTestFactory.createWithTestActionableHotspot();
+        MolecularCriterium criterium1 = MolecularCriteriumTestFactory.createWithTestActionableCharacteristic();
+        MolecularCriterium criterium3 = MolecularCriteriumTestFactory.createWithTestActionableHotspot();
         MolecularCriterium criterium2 = MolecularCriteriumTestFactory.createWithTestActionableGene();
-        MolecularCriterium criterium3 = MolecularCriteriumTestFactory.createWithTestActionableCharacteristic();
 
         List<MolecularCriterium> criteria = new ArrayList<>(List.of(criterium2, criterium3, criterium1));
         criteria.sort(new MolecularCriteriumComparator());

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/fusion/FusionTestFactory.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/fusion/FusionTestFactory.java
@@ -32,6 +32,11 @@ public final class FusionTestFactory {
     }
 
     @NotNull
+    public static ActionableFusion createTestActionableFusion() {
+        return actionableFusionBuilder().build();
+    }
+
+    @NotNull
     public static ImmutableActionableFusion.Builder actionableFusionBuilder() {
         return ImmutableActionableFusion.builder()
                 .from(MolecularTestFactory.createTestActionableEvent())

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/range/RangeTestFactory.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/molecular/range/RangeTestFactory.java
@@ -53,7 +53,7 @@ public final class RangeTestFactory {
     public static KnownExon createTestKnownExonForSource(@NotNull Knowledgebase source) {
         return knownExonBuilder().addSources(source).build();
     }
-
+    
     @NotNull
     public static ImmutableActionableRange.Builder actionableRangeBuilder() {
         return ImmutableActionableRange.builder().from(createTestRangeAnnotation()).from(MolecularTestFactory.createTestActionableEvent());

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
@@ -12,7 +12,6 @@ public class CompareFunctionsTest {
     public void canCompareSetsOfComparable() {
         assertEquals(-1, CompareFunctions.compareSetOfComparable(Set.of(), Set.of("string")));
         assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of("string")));
-        assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string1", "string2"), Set.of("string2", "string1")));
         assertEquals(1, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of()));
     }
 

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
@@ -12,6 +12,7 @@ public class CompareFunctionsTest {
     public void canCompareSetsOfComparable() {
         assertEquals(1, CompareFunctions.compareSetOfComparable(Set.of(), Set.of("string")));
         assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of("string")));
+        assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string1", "string2"), Set.of("string2", "string1")));
         assertEquals(-1, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of()));
     }
 

--- a/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
+++ b/datamodel/src/test/java/com/hartwig/serve/datamodel/util/CompareFunctionsTest.java
@@ -10,10 +10,10 @@ public class CompareFunctionsTest {
 
     @Test
     public void canCompareSetsOfComparable() {
-        assertEquals(1, CompareFunctions.compareSetOfComparable(Set.of(), Set.of("string")));
+        assertEquals(-1, CompareFunctions.compareSetOfComparable(Set.of(), Set.of("string")));
         assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of("string")));
         assertEquals(0, CompareFunctions.compareSetOfComparable(Set.of("string1", "string2"), Set.of("string2", "string1")));
-        assertEquals(-1, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of()));
+        assertEquals(1, CompareFunctions.compareSetOfComparable(Set.of("string"), Set.of()));
     }
 
     @Test


### PR DESCRIPTION
When checking the SERVE output of recent runs I discovered that there is some randomness in the sorting. Turned out that was caused by various issues on various levels. I think I got them all but still testing (one run per day). 

Since I am leaving for holiday soon, already opening this PR. Even if I didn't catch all causes for randomness I feel this PR is an improvement anyhow. 

(Side note: I considered making the datamodel enforce sorting but decided not to since there is no logical ordering anyways, and clients of the datamodel should not assume there is an ordering - the sorting is therefore an implementation detail simply to help with regression testing)

EDIT: I did 2 runs on 8th of July with same input and it produced identical output, which I hadn't succeeded in before. Makes me more confident I got all the randomness ironed out!